### PR TITLE
STRG-042: REST folder creation endpoint

### DIFF
--- a/src/Strg.Api/Endpoints/CreateFolderRequest.cs
+++ b/src/Strg.Api/Endpoints/CreateFolderRequest.cs
@@ -1,0 +1,9 @@
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// Request body for <c>POST /api/v1/drives/{driveId}/folders</c>. The <see cref="Path"/> is the
+/// virtual storage path of the leaf folder; intermediate segments are auto-created by the
+/// endpoint as virtual <c>FileItem(IsDirectory=true)</c> rows. Validated through
+/// <see cref="Strg.Core.Storage.StoragePath.Parse"/> — traversal attempts surface as a 400.
+/// </summary>
+public sealed record CreateFolderRequest(string Path);

--- a/src/Strg.Api/Endpoints/FileListEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileListEndpoints.cs
@@ -69,20 +69,9 @@ public static class FileListEndpoints
             return Results.NotFound();
         }
 
-        var items = result.Items.Select(ToDto).ToArray();
+        var items = result.Items.Select(FileItemDto.From).ToArray();
         return Results.Ok(new FileListResponse(items, result.Page, result.PageSize, result.TotalCount));
     }
-
-    private static FileItemDto ToDto(FileItem f) => new(
-        f.Id,
-        f.Name,
-        f.Path,
-        f.Size,
-        f.MimeType,
-        f.IsDirectory,
-        f.ContentHash,
-        f.CreatedAt,
-        f.UpdatedAt);
 }
 
 public record FileItemDto(
@@ -94,7 +83,25 @@ public record FileItemDto(
     bool IsDirectory,
     string? ContentHash,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt)
+{
+    /// <summary>
+    /// Projects a <see cref="FileItem"/> onto its wire-safe DTO. Centralised so non-listing
+    /// endpoints (folder creation in particular — STRG-042) can reuse the same projection
+    /// without re-deriving the field set, which would risk drift on additions like
+    /// <c>StorageKey</c> / <c>TenantId</c> / <c>ParentId</c> that are deliberately stripped here.
+    /// </summary>
+    public static FileItemDto From(FileItem file) => new(
+        file.Id,
+        file.Name,
+        file.Path,
+        file.Size,
+        file.MimeType,
+        file.IsDirectory,
+        file.ContentHash,
+        file.CreatedAt,
+        file.UpdatedAt);
+}
 
 public record FileListResponse(
     IReadOnlyList<FileItemDto> Items,

--- a/src/Strg.Api/Endpoints/FolderEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FolderEndpoints.cs
@@ -1,0 +1,165 @@
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using Strg.Api.Auth;
+using Strg.Core.Domain;
+using Strg.Core.Identity;
+using Strg.Core.Storage;
+using Strg.Infrastructure.Data;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-042 — REST endpoint that creates a virtual folder hierarchy in a drive. The endpoint is
+/// pure metadata: it never asks the storage backend to materialise a directory because
+/// <c>IStorageProvider</c> in strg works against virtual paths only — directories are
+/// <see cref="FileItem"/> rows with <see cref="FileItem.IsDirectory"/>=<see langword="true"/>,
+/// not OS-level directories.
+///
+/// <para><b>Auto-parent semantics.</b> A request for <c>"docs/2024/reports"</c> walks every
+/// path segment in order. For each segment, the handler queries
+/// <see cref="StrgDbContext.Files"/> by (driveId, currentPath). If the row is missing, the
+/// handler inserts a new directory row with <see cref="FileItem.ParentId"/> pointing at the
+/// previous segment's row, then commits. The per-segment commit is deliberate — without it the
+/// next segment's <see cref="FileItem.ParentId"/> would reference a transient
+/// <see cref="Guid.Empty"/> until the entire chain saves. Per the issue's Code Review Checklist,
+/// this is exactly the contract: "SaveChangesAsync called once per segment (to get IDs for
+/// ParentId)". The endpoint <i>is</i> the caller in CLAUDE.md's "caller commits" rule, and the
+/// repository pattern is preserved (we route through <see cref="StrgDbContext"/> directly here
+/// because per-segment id-resolution is the reason the rule exempts the caller).</para>
+///
+/// <para><b>Idempotency.</b> A re-request for an existing folder returns 200 with the existing
+/// row, never 409. The 409 path fires only when a path segment <i>collides with a non-directory
+/// file</i>: <c>"file.txt/subdir"</c> when <c>"file.txt"</c> exists as a file. Re-creating a
+/// folder is a safe no-op for clients that keep retrying after a transient failure.</para>
+///
+/// <para><b>Tenant isolation</b> rides on the global query filter on <see cref="StrgDbContext"/>'s
+/// file set — the endpoint cannot bypass it. <c>TenantId</c> on every new row is pinned from
+/// the JWT <c>tenant_id</c> claim, never from the request body. Cross-tenant request for
+/// someone else's drive collapses to 404 because the tenant filter excludes the drive row.</para>
+///
+/// <para><b>Path safety</b> is enforced by <see cref="StoragePath.Parse"/>: traversal
+/// (<c>"../etc"</c>), null bytes, encoded variants, Windows-reserved names — all surface as
+/// <see cref="StoragePathException"/>, which the endpoint catches and translates to a 400. The
+/// <c>Path</c> on every persisted <see cref="FileItem"/> row is therefore guaranteed normalised.
+/// </para>
+/// </summary>
+public static class FolderEndpoints
+{
+    public static IEndpointRouteBuilder MapFolderEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/drives/{driveId:guid}/folders", CreateFolderAsync)
+            .RequireAuthorization(AuthPolicies.FilesWrite)
+            .WithName("CreateFolder")
+            .WithTags("Folders")
+            .WithSummary("Create a virtual folder (and any missing parent segments) in a drive.")
+            .WithDescription(
+                "Creates the folder at the given path, auto-creating any missing parent path " +
+                "segments as virtual directory rows. Returns 200 OK with the leaf folder; the " +
+                "endpoint is idempotent — re-requesting an existing folder yields 200 OK and no " +
+                "duplicate row. Returns 409 Conflict when a path segment collides with an " +
+                "existing non-directory file. Returns 400 Bad Request when StoragePath.Parse " +
+                "rejects the input (traversal, null bytes, reserved names). No physical " +
+                "directory is created in the storage backend — strg uses virtual paths only.");
+
+        return app;
+    }
+
+    private static async Task<IResult> CreateFolderAsync(
+        Guid driveId,
+        CreateFolderRequest request,
+        StrgDbContext db,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        // Path validation BEFORE the drive existence check. A malformed path is the cheapest
+        // failure mode (no DB round-trip) and StoragePath.Parse is the project-wide gate against
+        // traversal/null-byte/reserved-name attacks. The catch surfaces as 400 because there is
+        // no central RFC 7807 mapping for StoragePathException on the REST surface (the GraphQL
+        // surface routes through StrgErrorFilter; REST endpoints translate inline).
+        StoragePath path;
+        try
+        {
+            path = StoragePath.Parse(request.Path);
+        }
+        catch (StoragePathException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+
+        // Drive existence check rides the tenant filter on db.Drives — a drive owned by a
+        // different tenant collapses to 404, never 403, to prevent cross-tenant enumeration.
+        // Mirrors the FileListEndpoints "UnknownDrive_Returns404" contract.
+        var driveExists = await db.Drives
+            .AnyAsync(d => d.Id == driveId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!driveExists)
+        {
+            return Results.NotFound();
+        }
+
+        var tenantId = user.GetTenantId();
+        var userId = user.GetUserId();
+
+        // Split on '/' against the normalised path. StoragePath.Normalize trims leading/trailing
+        // separators and collapses '\\' to '/', so a single split here yields exactly the
+        // segments — no empty entries to filter (Normalize already rejects "//" via
+        // ContainsTraversal). The struct's lack of a .Segments property is the reason for the
+        // inline split; we'd rather not promote the convenience accessor onto StoragePath until
+        // a second consumer needs it (folder creation is the first).
+        var segments = path.Value.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var currentPath = string.Empty;
+        FileItem? parent = null;
+
+        foreach (var segment in segments)
+        {
+            currentPath = currentPath.Length == 0 ? segment : $"{currentPath}/{segment}";
+
+            // Per-segment lookup — the unique (DriveId, Path) index makes this an index seek.
+            // The tenant + soft-delete filters on db.Files apply, so a row from another tenant
+            // (or a soft-deleted directory at the same path) is invisible here. That is the
+            // intended semantic: a re-created folder after a soft-delete is a fresh row.
+            var existing = await db.Files
+                .FirstOrDefaultAsync(f => f.DriveId == driveId && f.Path == currentPath, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (existing is null)
+            {
+                var dir = new FileItem
+                {
+                    TenantId = tenantId,
+                    DriveId = driveId,
+                    ParentId = parent?.Id,
+                    Name = segment,
+                    Path = currentPath,
+                    IsDirectory = true,
+                    Size = 0,
+                    CreatedBy = userId,
+                };
+                db.Files.Add(dir);
+
+                // Per-segment SaveChangesAsync. Without this, dir.Id is Guid.Empty when the next
+                // iteration reads it as parent.Id — every newly-inserted child would point at a
+                // null parent. The issue's Code Review Checklist explicitly pins this contract.
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                parent = dir;
+            }
+            else if (!existing.IsDirectory)
+            {
+                // 409 ONLY when the existing row is a file. A pre-existing directory is the
+                // idempotent path — the loop continues with the existing row as the new parent.
+                return Results.Conflict(new
+                {
+                    error = $"Path segment '{currentPath}' exists as a file.",
+                });
+            }
+            else
+            {
+                parent = existing;
+            }
+        }
+
+        // parent is guaranteed non-null because StoragePath.Parse rejects empty/whitespace input;
+        // segments.Length is therefore at least 1, and the loop body always assigns parent.
+        return Results.Ok(FileItemDto.From(parent!));
+    }
+}

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -409,6 +409,7 @@ app.MapDriveEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapFileListEndpoints();
 app.MapFileDeleteEndpoints();
+app.MapFolderEndpoints();
 app.MapUserRegistrationEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)

--- a/tests/Strg.Integration.Tests/Folders/FolderEndpointFixture.cs
+++ b/tests/Strg.Integration.Tests/Folders/FolderEndpointFixture.cs
@@ -1,0 +1,102 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Integration.Tests.Upload;
+
+namespace Strg.Integration.Tests.Folders;
+
+/// <summary>
+/// HTTP-level fixture for the STRG-042 folder-creation endpoint. Inherits
+/// <see cref="StrgTusUploadFixture"/>'s PostgreSQL + RabbitMQ container shape (one container
+/// per test class) and its seeded drive; adds direct <see cref="FileItem"/>-seeding so the
+/// 409-on-file-collision test can pre-seed a non-directory row at a specific path without
+/// running an upload, plus a count-by-driveId helper for the idempotency assertion.
+///
+/// <para>Paths are seeded in storage-normalized form — no leading or trailing slash, mirroring
+/// what <c>StoragePath.Normalize</c> produces in production and what the existing fixtures
+/// (FileListFixture, FileDeleteFixture) seed. Aligning the seed shape with production keeps
+/// any path-format regression in the listing/deletion code observable here too.</para>
+/// </summary>
+public sealed class FolderEndpointFixture : StrgTusUploadFixture
+{
+    /// <summary>
+    /// Seeds a single <see cref="FileItem"/> on the fixture's drive. Used by the 409 test to
+    /// pre-seed a non-directory row at a path that the endpoint will later try to walk into;
+    /// without the pre-seed, the endpoint would simply auto-create a directory at that path.
+    /// </summary>
+    public async Task<Guid> SeedFileAsync(
+        string path,
+        bool isDirectory = false,
+        string? mimeType = null,
+        long size = 0,
+        CancellationToken cancellationToken = default)
+    {
+        var name = path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
+
+        await using var ctx = NewDbContext();
+        var file = new FileItem
+        {
+            TenantId = TenantId,
+            DriveId = DriveId,
+            Name = name,
+            Path = path,
+            IsDirectory = isDirectory,
+            Size = size,
+            MimeType = mimeType ?? (isDirectory ? "inode/directory" : "application/octet-stream"),
+            CreatedBy = UserId,
+            VersionCount = isDirectory ? 0 : 1,
+        };
+        ctx.Files.Add(file);
+        await ctx.SaveChangesAsync(cancellationToken);
+        return file.Id;
+    }
+
+    /// <summary>
+    /// Counts <see cref="FileItem"/> rows on the fixture's drive whose path starts with the
+    /// given prefix. Used by the idempotency test (TC-002) to assert that a re-create call
+    /// did NOT duplicate any directory rows. The prefix must be storage-normalized to match
+    /// the canonical path shape.
+    /// </summary>
+    public async Task<int> CountByPathPrefixAsync(string prefix, CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        return await ctx.Files
+            .Where(f => f.DriveId == DriveId && (f.Path == prefix || f.Path.StartsWith(prefix + "/")))
+            .CountAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a single <see cref="FileItem"/> by its (drive-scoped) path. The fixture's drive is
+    /// the only drive seeded in this class, so an unambiguous lookup by path is sufficient.
+    /// Returns null for paths the endpoint did not (or refused to) materialise.
+    /// </summary>
+    public async Task<FileItem?> GetByPathAsync(string path, CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        return await ctx.Files
+            .FirstOrDefaultAsync(f => f.DriveId == DriveId && f.Path == path, cancellationToken);
+    }
+
+    /// <summary>
+    /// POSTs the password grant with a caller-supplied scope list. Mirrors the equivalent
+    /// helper in FileListFixture / FileDeleteFixture — needed to exercise the 403 path for
+    /// callers authenticated without <c>files.write</c>.
+    /// </summary>
+    public async Task<string> AuthenticateWithScopesAsync(string scopes)
+    {
+        using var client = CreateClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = UserEmail,
+            ["password"] = TestPassword,
+            ["client_id"] = "strg-default",
+            ["scope"] = scopes,
+        });
+        using var response = await client.PostAsync("/connect/token", form);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("access_token").GetString()!;
+    }
+}

--- a/tests/Strg.Integration.Tests/Folders/FolderEndpointTests.cs
+++ b/tests/Strg.Integration.Tests/Folders/FolderEndpointTests.cs
@@ -1,0 +1,219 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Strg.Integration.Tests.Folders;
+
+/// <summary>
+/// STRG-042 — REST folder-creation endpoint integration tests. Class-scoped fixture
+/// (<see cref="FolderEndpointFixture"/>) gives one PostgreSQL + RabbitMQ container shared across
+/// every test method. Each test scopes its created folders under a unique top-level segment so
+/// state from earlier tests in the same class can't bleed into later assertions (the
+/// <c>(DriveId, Path)</c> unique index would otherwise produce flake-prone insert collisions
+/// between tests).
+/// </summary>
+public sealed class FolderEndpointTests(FolderEndpointFixture fx) : IClassFixture<FolderEndpointFixture>
+{
+    [Fact]
+    public async Task Tc001_CreatesAllParentSegments()
+    {
+        // TC-001 from STRG-042: POST path="a/b/c" with no existing parents → a, a/b, a/b/c all
+        // created. The leaf row is what the endpoint returns; the parent rows must exist as
+        // separate FileItem(IsDirectory=true) entries with the right ParentId chain.
+        var marker = $"tc001-{Guid.NewGuid():N}";
+        var leafPath = $"{marker}/b/c";
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = leafPath });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<FolderResponseDto>();
+        body.Should().NotBeNull();
+        body!.Path.Should().Be(leafPath);
+        body.IsDirectory.Should().BeTrue();
+        body.Name.Should().Be("c");
+
+        // Every intermediate directory must exist as a row, with the parent chain wired:
+        //   marker          -> ParentId null
+        //   marker/b        -> ParentId = id of marker
+        //   marker/b/c      -> ParentId = id of marker/b
+        var rootDir = await fx.GetByPathAsync(marker);
+        var midDir = await fx.GetByPathAsync($"{marker}/b");
+        var leafDir = await fx.GetByPathAsync(leafPath);
+
+        rootDir.Should().NotBeNull();
+        rootDir!.IsDirectory.Should().BeTrue();
+        rootDir.ParentId.Should().BeNull("the top-level segment has no parent");
+
+        midDir.Should().NotBeNull();
+        midDir!.IsDirectory.Should().BeTrue();
+        midDir.ParentId.Should().Be(rootDir.Id, "the middle segment's parent is the root segment row");
+
+        leafDir.Should().NotBeNull();
+        leafDir!.IsDirectory.Should().BeTrue();
+        leafDir.ParentId.Should().Be(midDir.Id, "the leaf segment's parent is the middle segment row");
+        leafDir.Id.Should().Be(body.Id, "the response body's id matches the persisted leaf row");
+    }
+
+    [Fact]
+    public async Task Tc002_AlreadyExists_IsIdempotent_NoDuplicate()
+    {
+        // TC-002 from STRG-042: re-POSTing the same path returns 200 with the existing row and
+        // does NOT create a second row. Exercises the idempotency carve-out that makes folder
+        // creation safe to retry on transient client failures.
+        var marker = $"tc002-{Guid.NewGuid():N}";
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var first = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = marker });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var firstBody = await first.Content.ReadFromJsonAsync<FolderResponseDto>();
+
+        // Second call — same path, fresh request — must return 200 with the SAME id.
+        var second = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = marker });
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        var secondBody = await second.Content.ReadFromJsonAsync<FolderResponseDto>();
+
+        secondBody!.Id.Should().Be(firstBody!.Id, "idempotent re-create must return the existing row, not a new one");
+
+        // Verify the DB state directly: a single row with that path under our marker prefix.
+        var count = await fx.CountByPathPrefixAsync(marker);
+        count.Should().Be(1, "no duplicate folder row may be created on re-POST");
+    }
+
+    [Fact]
+    public async Task Tc003_PathSegmentCollidesWithFile_Returns409()
+    {
+        // TC-003 from STRG-042: POST path="file.txt/subdir" where file.txt is a non-directory
+        // FileItem → 409 Conflict. The endpoint must NOT silently auto-create a directory row
+        // at the colliding path; it must surface the conflict to the caller.
+        var marker = $"tc003-{Guid.NewGuid():N}";
+        var fileSegment = $"{marker}/file.txt";
+
+        // Pre-seed a non-directory file at the path the endpoint will try to walk through.
+        await fx.SeedFileAsync(fileSegment, isDirectory: false);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = $"{fileSegment}/subdir" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        // The colliding row must remain a non-directory; the endpoint must NOT have flipped its
+        // IsDirectory flag, and no "subdir" child must exist either.
+        var collidingRow = await fx.GetByPathAsync(fileSegment);
+        collidingRow.Should().NotBeNull();
+        collidingRow!.IsDirectory.Should().BeFalse("the pre-existing file must remain a file");
+        var subdir = await fx.GetByPathAsync($"{fileSegment}/subdir");
+        subdir.Should().BeNull("no descendant may be created when the parent segment collision fires 409");
+    }
+
+    [Fact]
+    public async Task Tc004_PathTraversal_Returns400()
+    {
+        // TC-004 from STRG-042: POST path="../etc" → 400. StoragePath.Parse rejects traversal
+        // ("..") at parse time and the endpoint translates the StoragePathException to a
+        // BadRequest result.
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = "../etc" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UnknownDrive_Returns404()
+    {
+        // Drive existence check is intentionally a 404 (not 403) to prevent enumeration of
+        // drives belonging to other tenants — mirrors FileListEndpoints' UnknownDrive_Returns404.
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{Guid.NewGuid()}/folders",
+            new { path = "any" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task WithoutFilesWriteScope_Returns403()
+    {
+        // Authenticate with files.read but NOT files.write — the policy framework rejects with
+        // 403 before the handler ever runs. Mirrors FileListTests.WithoutFilesReadScope_Returns403.
+        var token = await fx.AuthenticateWithScopesAsync("files.read files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = $"scope-test-{Guid.NewGuid():N}" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Returns401()
+    {
+        using var client = fx.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = $"unauth-{Guid.NewGuid():N}" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ExistingDirectory_DescentContinues_NoDuplicate()
+    {
+        // Layered idempotency: when "a" exists as a directory, POST "a/b" must reuse "a" as the
+        // parent — not duplicate it. Pins the "else if existing is directory → continue" branch
+        // alongside the TC-002 full-match idempotency path.
+        var marker = $"reuse-{Guid.NewGuid():N}";
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        // First request creates "marker" only.
+        var step1 = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = marker });
+        step1.StatusCode.Should().Be(HttpStatusCode.OK);
+        var step1Body = await step1.Content.ReadFromJsonAsync<FolderResponseDto>();
+
+        // Second request asks for "marker/b" — must reuse step1Body.Id as parent.
+        var step2 = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = $"{marker}/b" });
+        step2.StatusCode.Should().Be(HttpStatusCode.OK);
+        var step2Body = await step2.Content.ReadFromJsonAsync<FolderResponseDto>();
+
+        var leaf = await fx.GetByPathAsync($"{marker}/b");
+        leaf.Should().NotBeNull();
+        leaf!.ParentId.Should().Be(step1Body!.Id, "the existing 'marker' folder must be reused as the parent of 'marker/b'");
+
+        var count = await fx.CountByPathPrefixAsync(marker);
+        count.Should().Be(2, "exactly two rows: 'marker' (reused) and 'marker/b' (new)");
+    }
+
+    private sealed record FolderResponseDto(
+        Guid Id,
+        string Name,
+        string Path,
+        long Size,
+        string MimeType,
+        bool IsDirectory,
+        string? ContentHash,
+        DateTimeOffset CreatedAt,
+        DateTimeOffset UpdatedAt);
+}


### PR DESCRIPTION
## Summary
- POST /api/v1/drives/{driveId}/folders
- Auto-creates parent path segments as virtual FileItems
- Idempotent (200 on existing folder)
- StoragePath.Parse → 400 on traversal

## Test plan
- [x] TC-001 nested path creation in single request
- [x] TC-002 idempotent — same path twice → no duplicate
- [x] TC-003 path collides with existing file → 409
- [x] TC-004 traversal → 400

Closes #14