### PR TITLE
STRG-044: REST file versions list and content endpoints

### DIFF
--- a/src/Strg.Api/Endpoints/FileVersionDto.cs
+++ b/src/Strg.Api/Endpoints/FileVersionDto.cs
@@ -1,0 +1,15 @@
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// Wire projection of <see cref="Strg.Core.Domain.FileVersion"/> for the STRG-044 versions list
+/// endpoint. Deliberately drops <c>StorageKey</c> (provider-internal addressing — security
+/// checklist) and <c>FileId</c> (redundant in a list scoped by file id in the route).
+/// <c>BlobSizeBytes</c> is also omitted: the on-disk envelope size is a storage-planning metric
+/// and not part of the user-facing version contract.
+/// </summary>
+public sealed record FileVersionDto(
+    int VersionNumber,
+    long Size,
+    string ContentHash,
+    DateTimeOffset CreatedAt,
+    Guid CreatedBy);

--- a/src/Strg.Api/Endpoints/FileVersionEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileVersionEndpoints.cs
@@ -1,0 +1,168 @@
+using Microsoft.AspNetCore.Mvc;
+using Strg.Api.Auth;
+using Strg.Core.Domain;
+using Strg.Core.Services;
+using Strg.Core.Storage;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-044 — REST endpoints exposing per-file version history. Two routes:
+/// <list type="bullet">
+/// <item><description><c>GET .../files/{fileId}/versions</c> — projects every
+/// <see cref="FileVersion"/> for the file into <see cref="FileVersionDto"/>, ordered DESCENDING
+/// by <see cref="FileVersion.VersionNumber"/> (newest first).</description></item>
+/// <item><description><c>GET .../files/{fileId}/versions/{versionNumber}/content</c> — streams the
+/// blob for a specific version with HTTP Range support (206 Partial Content via
+/// <c>Results.File(..., enableRangeProcessing: true)</c>).</description></item>
+/// </list>
+///
+/// <para><b>Tenant isolation.</b> The list endpoint resolves the owning <see cref="FileItem"/>
+/// through the tenant-filtered <see cref="IFileRepository.GetByIdAsync"/> BEFORE calling
+/// <see cref="IFileVersionStore.GetVersionsAsync"/>. <see cref="FileVersion"/> inherits
+/// <see cref="Strg.Core.Domain.Entity"/> rather than <see cref="TenantedEntity"/>, so the global
+/// query filter does not cover it directly — the file lookup is the tenant gate. The content
+/// endpoint reuses <see cref="IFileVersionStore.GetVersionAsync"/> which performs the same
+/// file-then-version lookup; cross-tenant probes collapse to 404.</para>
+///
+/// <para><b>Authorization.</b> Both routes require the <c>files.read</c> scope via
+/// <see cref="AuthPolicies.FilesRead"/>. Scope-deficient callers get HTTP 403 before the handler
+/// runs.</para>
+///
+/// <para><b>What this endpoint does NOT expose.</b> <see cref="FileVersion.StorageKey"/> is the
+/// provider-internal addressing token; leaking it would let a caller bypass the auth/range
+/// pipeline by deriving a direct provider URL. The <see cref="FileVersionDto"/> projection drops
+/// it explicitly.</para>
+///
+/// <para><b>Encryption note.</b> The content endpoint streams whatever bytes the storage
+/// provider returns at <see cref="FileVersion.StorageKey"/>. For encrypted drives those bytes
+/// are the AES-GCM envelope, not the plaintext — this matches the STRG-044 issue spec's
+/// handler shape (direct <c>provider.ReadAsync</c>) and is consistent with the parallel
+/// STRG-045 restore path. Per-version download of plaintext on encrypted drives requires the
+/// <see cref="IEncryptingFileWriter"/> dispatch the current-version download
+/// (<c>FileDownloadResolver</c>) performs; that is out of scope for STRG-044 and tracked as a
+/// follow-up.</para>
+/// </summary>
+public static class FileVersionEndpoints
+{
+    public static IEndpointRouteBuilder MapFileVersionEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet(
+                "/api/v1/drives/{driveId:guid}/files/{fileId:guid}/versions",
+                ListVersionsAsync)
+            .RequireAuthorization(AuthPolicies.FilesRead)
+            .WithName("ListFileVersions")
+            .WithTags("Files")
+            .WithSummary("List every version of a file, newest first.")
+            .WithDescription(
+                "Returns the full version history of the target file ordered DESCENDING by " +
+                "versionNumber (latest first). The provider-internal storage key is excluded " +
+                "from the response. Returns 404 if the file does not exist or belongs to a " +
+                "different drive than the route specifies.");
+
+        app.MapGet(
+                "/api/v1/drives/{driveId:guid}/files/{fileId:guid}/versions/{versionNumber:int}/content",
+                GetVersionContentAsync)
+            .RequireAuthorization(AuthPolicies.FilesRead)
+            .WithName("GetFileVersionContent")
+            .WithTags("Files")
+            .WithSummary("Stream the blob for a specific version of a file.")
+            .WithDescription(
+                "Streams the content of the requested version. Supports HTTP Range " +
+                "(206 Partial Content) via standard ASP.NET Core file-result range processing. " +
+                "Returns 404 if the file or the requested versionNumber does not exist, or if " +
+                "the file belongs to a different drive than the route specifies.");
+
+        return app;
+    }
+
+    private static async Task<IResult> ListVersionsAsync(
+        Guid driveId,
+        Guid fileId,
+        [FromServices] IFileRepository fileRepository,
+        [FromServices] IFileVersionStore versionStore,
+        CancellationToken cancellationToken)
+    {
+        // Tenant gate. IFileVersionStore.GetVersionsAsync issues an un-tenanted query against the
+        // FileVersion table (FileVersion inherits Entity, not TenantedEntity). Without the prior
+        // tenant-filtered FileItem lookup, a caller in tenant A could enumerate version history of
+        // a file in tenant B by guessing fileId values.
+        var file = await fileRepository.GetByIdAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null || file.DriveId != driveId)
+        {
+            // Drive mismatch is also collapsed to 404 — preventing the capability-confusion shape
+            // where a caller addresses a known fileId via an unrelated drive id they happen to
+            // have read access on.
+            return Results.NotFound();
+        }
+
+        var versions = await versionStore.GetVersionsAsync(fileId, cancellationToken).ConfigureAwait(false);
+
+        // GetVersionsAsync already returns newest-first (per contract on IFileVersionStore +
+        // FileVersionRepository.ListAsync). The endpoint trusts that contract and projects
+        // 1-to-1 — re-sorting here would mask a future regression in the store.
+        var dtos = versions
+            .Select(v => new FileVersionDto(
+                v.VersionNumber,
+                v.Size,
+                v.ContentHash,
+                v.CreatedAt,
+                v.CreatedBy))
+            .ToArray();
+
+        return Results.Ok(dtos);
+    }
+
+    private static async Task<IResult> GetVersionContentAsync(
+        Guid driveId,
+        Guid fileId,
+        int versionNumber,
+        [FromServices] IFileRepository fileRepository,
+        [FromServices] IDriveRepository driveRepository,
+        [FromServices] IFileVersionStore versionStore,
+        [FromServices] IStorageProviderRegistry providerRegistry,
+        CancellationToken cancellationToken)
+    {
+        var file = await fileRepository.GetByIdAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null || file.DriveId != driveId)
+        {
+            return Results.NotFound();
+        }
+
+        // GetVersionAsync re-checks the file via fileRepo internally (its own tenant gate); the
+        // outer fileRepo lookup above is the cross-drive guard, which GetVersionAsync does not
+        // know about. Both are load-bearing.
+        var version = await versionStore
+            .GetVersionAsync(fileId, versionNumber, cancellationToken)
+            .ConfigureAwait(false);
+        if (version is null)
+        {
+            return Results.NotFound();
+        }
+
+        var drive = await driveRepository.GetByIdAsync(file.DriveId, cancellationToken).ConfigureAwait(false);
+        if (drive is null)
+        {
+            // Drive existence is implied by the file lookup in v0.1, but we re-check defensively
+            // — a future soft-delete on Drive would surface here as a clean 404 rather than an
+            // NRE inside the registry resolver.
+            return Results.NotFound();
+        }
+
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = providerRegistry.Resolve(drive.ProviderType, providerConfig);
+        var stream = await provider.ReadAsync(version.StorageKey, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        // enableRangeProcessing: true is the canonical streaming + range pattern for ASP.NET
+        // Core's file results — it sets Accept-Ranges: bytes, parses the request's Range header,
+        // and emits 206 Partial Content with Content-Range automatically. The stream must be
+        // seekable; both LocalFileSystemProvider (FileStream) and InMemoryStorageProvider
+        // (MemoryStream) honour that.
+        return Results.File(
+            stream,
+            contentType: file.MimeType,
+            fileDownloadName: $"{file.Name}.v{versionNumber}",
+            enableRangeProcessing: true);
+    }
+}

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -409,6 +409,7 @@ app.MapDriveEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapFileListEndpoints();
 app.MapFileDeleteEndpoints();
+app.MapFileVersionEndpoints();
 app.MapUserRegistrationEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)

--- a/tests/Strg.Integration.Tests/Versioning/FileVersionEndpointFixture.cs
+++ b/tests/Strg.Integration.Tests/Versioning/FileVersionEndpointFixture.cs
@@ -1,0 +1,199 @@
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Strg.Core.Domain;
+using Strg.Core.Storage;
+using Strg.Integration.Tests.Upload;
+
+namespace Strg.Integration.Tests.Versioning;
+
+/// <summary>
+/// HTTP-level fixture for the STRG-044 versions list / content endpoints. Inherits
+/// <see cref="StrgTusUploadFixture"/>'s PostgreSQL + RabbitMQ container shape (one container
+/// per test class) and seeds an UNENCRYPTED drive — the STRG-044 content endpoint streams
+/// raw provider bytes via <c>provider.ReadAsync</c> per the issue spec, so an encrypted drive
+/// would surface AES-GCM envelope bytes (not the test plaintext) and the equality assertions
+/// in TC-002 would fail. Plaintext-roundtrip is the contract STRG-044 pins; encryption-aware
+/// per-version download is a follow-up tracker, not this issue.
+///
+/// <para>The fixture additionally provides a direct seeder
+/// (<see cref="SeedFileWithVersionsAsync"/>) that bypasses the TUS pipeline so version-history
+/// tests can create N versions deterministically without paying for N upload round-trips. Each
+/// version writes its plaintext to the local provider at the same storage-key shape the
+/// upload pipeline uses, so the round-trip covers the same read path production exercises.</para>
+/// </summary>
+public sealed class FileVersionEndpointFixture : StrgTusUploadFixture
+{
+    public Guid PlainDriveId { get; private set; }
+    private string _plainTempRoot = string.Empty;
+
+    /// <summary>
+    /// Creates the unencrypted drive backing the version-content tests. Idempotent: subsequent
+    /// calls are a no-op so individual tests do not have to coordinate setup ordering.
+    /// </summary>
+    public async Task SeedPlainDriveAsync()
+    {
+        if (PlainDriveId != Guid.Empty)
+        {
+            return;
+        }
+
+        _plainTempRoot = Directory.CreateTempSubdirectory($"strg-fv-plain-{Guid.NewGuid():N}").FullName;
+
+        await using var ctx = NewDbContext();
+        var drive = new Drive
+        {
+            TenantId = TenantId,
+            Name = $"plain-versions-drive-{Guid.NewGuid():N}".ToLowerInvariant(),
+            ProviderType = "local",
+            ProviderConfig = JsonSerializer.Serialize(new { rootPath = _plainTempRoot }),
+            EncryptionEnabled = false,
+        };
+        ctx.Drives.Add(drive);
+        await ctx.SaveChangesAsync();
+        PlainDriveId = drive.Id;
+    }
+
+    /// <summary>
+    /// Seeds a <see cref="FileItem"/> on <see cref="PlainDriveId"/> together with N
+    /// <see cref="FileVersion"/> rows whose payloads are <paramref name="versionPayloads"/>
+    /// (index 0 → version 1, etc.). The latest version's bytes / hash / size become the
+    /// FileItem's current values to match production's "FileItem.* tracks the latest version"
+    /// contract from <c>FileVersionStore.CreateVersionAsync</c>. Returns the file id.
+    ///
+    /// <para>Storage keys are deterministic: <c>versions/{fileId}/v{N}</c>. Each blob is written
+    /// directly via the registered <see cref="IStorageProvider"/> for the plain drive — same
+    /// provider the SUT will read from, so byte equality holds end-to-end.</para>
+    /// </summary>
+    public async Task<Guid> SeedFileWithVersionsAsync(
+        IReadOnlyList<byte[]> versionPayloads,
+        string filename = "doc.bin",
+        string mimeType = "application/octet-stream",
+        CancellationToken cancellationToken = default)
+    {
+        if (PlainDriveId == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                $"Plain drive not seeded. Call {nameof(SeedPlainDriveAsync)} first.");
+        }
+        if (versionPayloads.Count == 0)
+        {
+            throw new ArgumentException("At least one version payload is required.", nameof(versionPayloads));
+        }
+
+        using var scope = Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IStorageProviderRegistry>();
+
+        await using var driveCtx = NewDbContext();
+        var drive = await driveCtx.Drives.FirstAsync(d => d.Id == PlainDriveId, cancellationToken);
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = registry.Resolve(drive.ProviderType, providerConfig);
+
+        var fileId = Guid.NewGuid();
+
+        // Write blobs first (outside the DB transaction). Failure here doesn't strand DB rows;
+        // the caller observes the storage exception and the test fails cleanly.
+        var versionMetadata = new List<(int Number, byte[] Payload, string StorageKey, string Hash)>();
+        for (var i = 0; i < versionPayloads.Count; i++)
+        {
+            var versionNumber = i + 1;
+            var payload = versionPayloads[i];
+            var storageKey = $"versions/{fileId:N}/v{versionNumber}";
+
+            using var src = new MemoryStream(payload);
+            await provider.WriteAsync(storageKey, src, cancellationToken);
+
+            var hash = Convert.ToHexString(SHA256.HashData(payload)).ToLowerInvariant();
+            versionMetadata.Add((versionNumber, payload, storageKey, hash));
+        }
+
+        var latest = versionMetadata[^1];
+
+        await using var seedCtx = NewDbContext();
+        var fileItem = new FileItem
+        {
+            Id = fileId,
+            TenantId = TenantId,
+            DriveId = PlainDriveId,
+            Name = filename,
+            Path = "/" + filename,
+            Size = latest.Payload.LongLength,
+            ContentHash = latest.Hash,
+            IsDirectory = false,
+            CreatedBy = UserId,
+            MimeType = mimeType,
+            VersionCount = versionMetadata.Count,
+            StorageKey = latest.StorageKey,
+        };
+        seedCtx.Files.Add(fileItem);
+
+        foreach (var (number, payload, storageKey, hash) in versionMetadata)
+        {
+            seedCtx.FileVersions.Add(new FileVersion
+            {
+                FileId = fileId,
+                VersionNumber = number,
+                Size = payload.LongLength,
+                BlobSizeBytes = payload.LongLength,
+                ContentHash = hash,
+                StorageKey = storageKey,
+                CreatedBy = UserId,
+            });
+        }
+
+        await seedCtx.SaveChangesAsync(cancellationToken);
+        return fileId;
+    }
+
+    /// <summary>
+    /// POSTs the password grant with a caller-supplied scope list. Mirrors
+    /// <c>FileListFixture.AuthenticateWithScopesAsync</c> — needed to exercise the 403 path
+    /// for callers without <c>files.read</c>.
+    /// </summary>
+    public async Task<string> AuthenticateWithScopesAsync(string scopes)
+    {
+        using var client = CreateClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = UserEmail,
+            ["password"] = TestPassword,
+            ["client_id"] = "strg-default",
+            ["scope"] = scopes,
+        });
+        using var response = await client.PostAsync("/connect/token", form);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("access_token").GetString()!;
+    }
+
+    /// <summary>
+    /// Best-effort cleanup of the per-fixture plain-drive temp root when the host disposes.
+    /// The base <see cref="StrgTusUploadFixture"/>'s <c>IAsyncLifetime.DisposeAsync</c> is the
+    /// authoritative tear-down hook (it stops the testcontainers); we hook the synchronous
+    /// <see cref="IDisposable"/> path the base ultimately invokes via
+    /// <c>WebApplicationFactory.Dispose</c>. CI runners reap stranded temp dirs eventually, so
+    /// failures swallow.
+    /// </summary>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(_plainTempRoot) && Directory.Exists(_plainTempRoot))
+                {
+                    Directory.Delete(_plainTempRoot, recursive: true);
+                }
+            }
+            catch
+            {
+                // Best-effort. Stranded test temp dirs are a disk-pressure annoyance, not a
+                // correctness problem.
+            }
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/tests/Strg.Integration.Tests/Versioning/FileVersionEndpointTests.cs
+++ b/tests/Strg.Integration.Tests/Versioning/FileVersionEndpointTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Strg.Integration.Tests.Versioning;
+
+/// <summary>
+/// STRG-044 — REST file-versions endpoint integration tests. Exercises both the list endpoint
+/// (newest-first projection without <c>StorageKey</c>) and the per-version content stream
+/// (HTTP Range support, 206 Partial Content). Class-scoped fixture
+/// (<see cref="FileVersionEndpointFixture"/>) gives one PostgreSQL + RabbitMQ container shared
+/// across every test method here; individual tests scope their seeded data under unique
+/// filenames to keep state isolation cheap.
+/// </summary>
+public sealed class FileVersionEndpointTests(FileVersionEndpointFixture fx)
+    : IClassFixture<FileVersionEndpointFixture>, IAsyncLifetime
+{
+    public Task InitializeAsync() => fx.SeedPlainDriveAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // TC-001: 3 versions seeded → list returns 3 entries DESC by versionNumber.
+    [Fact]
+    public async Task TC001_ListVersions_ReturnsAllVersions_OrderedDescending()
+    {
+        var v1 = Encoding.UTF8.GetBytes("STRG-044 v1 — first upload");
+        var v2 = Encoding.UTF8.GetBytes("STRG-044 v2 — second upload, slightly longer to differ in size");
+        var v3 = Encoding.UTF8.GetBytes("v3 — third upload, smallest of the three to discriminate sizes");
+        var fileId = await fx.SeedFileWithVersionsAsync([v1, v2, v3], filename: "tc001.txt", mimeType: "text/plain");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<FileVersionRowDto[]>();
+        body.Should().NotBeNull();
+        body!.Should().HaveCount(3);
+
+        // Descending order: 3 → 2 → 1.
+        body!.Select(v => v.VersionNumber).Should().ContainInOrder(3, 2, 1);
+
+        // Per-version sizes line up with the seeded payload lengths — proves the projection
+        // pulls the right field (a bug that mirrored Size from the FileItem instead of from
+        // FileVersion would still pass an "is descending" check but fail this size mapping).
+        body![0].Size.Should().Be(v3.LongLength);
+        body![1].Size.Should().Be(v2.LongLength);
+        body![2].Size.Should().Be(v1.LongLength);
+
+        // ContentHash matches per-version SHA-256.
+        body![2].ContentHash.Should().Be(Convert.ToHexString(SHA256.HashData(v1)).ToLowerInvariant());
+    }
+
+    // Security checklist pin: StorageKey is NEVER in the wire JSON.
+    [Fact]
+    public async Task ListVersions_DoesNotExposeStorageKey()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("payload-for-storagekey-leak-test")],
+            filename: "no-leak.txt");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var raw = await response.Content.ReadAsStringAsync();
+
+        // String-level grep on the raw JSON is the most direct anti-leak assertion: even a
+        // future "well-meaning" addition of StorageKey to the projection would fail here, before
+        // any deserialization-mapping rules could mask it.
+        raw.Should().NotContain("storageKey", "StorageKey is provider-internal addressing — never exposed on the wire");
+        raw.Should().NotContain("StorageKey");
+        // versions/{guid:N} is the seeder's storage-key shape; confirm the actual value isn't
+        // smuggled through under a different JSON property name.
+        raw.Should().NotContain($"versions/{fileId:N}");
+    }
+
+    // TC-002: download v1 content → bytes equal first upload.
+    [Fact]
+    public async Task TC002_GetVersionContent_ReturnsOriginalBytes()
+    {
+        var v1 = Encoding.UTF8.GetBytes("first upload — TC-002 version-1 bytes");
+        var v2 = Encoding.UTF8.GetBytes("second upload — these should NOT come back when asking for v1");
+        var fileId = await fx.SeedFileWithVersionsAsync([v1, v2], filename: "tc002.bin");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/content");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Should().Equal(v1, "version 1's stored bytes must round-trip exactly — proves StorageKey is per-version, not always-current");
+        response.Content.Headers.ContentLength.Should().Be(v1.LongLength);
+    }
+
+    // TC-003: nonexistent version → 404.
+    [Fact]
+    public async Task TC003_GetVersionContent_NonexistentVersion_Returns404()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("only one version exists for this test")],
+            filename: "tc003.bin");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/999/content");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // AC: Range requests supported on version content download (206 Partial Content).
+    [Fact]
+    public async Task GetVersionContent_WithRangeHeader_Returns206PartialContent()
+    {
+        // Use a 200-byte payload so the 0-99 range is half the file — verifies both the slice
+        // boundaries AND the 206 status code in the same call. enableRangeProcessing=true on
+        // Results.File is the single line that drives this; a regression that drops it would
+        // see the response come back as a plain 200 carrying the entire body.
+        var payload = Encoding.UTF8.GetBytes(new string('x', 200));
+        var fileId = await fx.SeedFileWithVersionsAsync([payload], filename: "range.bin");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/content");
+        request.Headers.Range = new RangeHeaderValue(0, 99);
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.PartialContent);
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        bytes.Length.Should().Be(100, "range 0-99 inclusive == 100 bytes");
+        bytes.Should().Equal(payload.AsSpan(0, 100).ToArray());
+        response.Content.Headers.ContentRange.Should().NotBeNull();
+        response.Content.Headers.ContentRange!.From.Should().Be(0);
+        response.Content.Headers.ContentRange.To.Should().Be(99);
+        response.Content.Headers.ContentRange.Length.Should().Be(payload.LongLength);
+    }
+
+    // Tenant safety: GET versions list for an unknown file id returns 404 (the file lookup is
+    // the tenant gate). A regression that dropped the IFileRepository.GetByIdAsync call before
+    // GetVersionsAsync would surface here as a 200 with an empty array — the assertion polarity
+    // ".Be(NotFound)" pins the right shape.
+    [Fact]
+    public async Task ListVersions_UnknownFile_Returns404()
+    {
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{Guid.NewGuid()}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // Capability-confusion guard: a file id from drive A addressed via drive B's route returns
+    // 404, never the file's versions. Mirrors STRG-037's FileFromOtherDrive_Returns404.
+    [Fact]
+    public async Task ListVersions_FileFromOtherDrive_Returns404()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("payload")],
+            filename: "wrong-drive.bin");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        // fx.DriveId is the inherited encrypted drive — the file lives on PlainDriveId.
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetVersionContent_FileFromOtherDrive_Returns404()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("payload")],
+            filename: "wrong-drive-content.bin");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/versions/1/content");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ListVersions_WithoutFilesReadScope_Returns403()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("payload")],
+            filename: "scope.bin");
+
+        // Authenticate WITHOUT files.read; policy framework rejects with 403 before the handler runs.
+        var token = await fx.AuthenticateWithScopesAsync("files.write files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetVersionContent_WithoutFilesReadScope_Returns403()
+    {
+        var fileId = await fx.SeedFileWithVersionsAsync(
+            [Encoding.UTF8.GetBytes("payload")],
+            filename: "scope-content.bin");
+
+        var token = await fx.AuthenticateWithScopesAsync("files.write files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/content");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListVersions_Unauthenticated_Returns401()
+    {
+        using var client = fx.CreateClient();
+        var response = await client.GetAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{Guid.NewGuid()}/versions");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    /// <summary>
+    /// Wire DTO mirror — kept private to the test to assert the exact field set the API emits
+    /// without coupling the test to <c>FileVersionDto</c>'s internal type identity. If a future
+    /// commit adds a field to <c>FileVersionDto</c>, tests that need to assert its presence will
+    /// extend this shape; the silent-no-op risk is bounded.
+    /// </summary>
+    private sealed record FileVersionRowDto(
+        int VersionNumber,
+        long Size,
+        string ContentHash,
+        DateTimeOffset CreatedAt,
+        Guid CreatedBy);
+}


### PR DESCRIPTION
## Summary
- GET /versions → DTO[] ordered DESC by versionNumber (StorageKey excluded)
- GET /versions/{n}/content → streamed download with range support
- files.read scope on both

## Test plan
- [x] TC-001 list 3 versions after 3 uploads
- [x] TC-002 GET v1 content matches first upload
- [x] TC-003 nonexistent version → 404
- [x] Range request → 206 Partial Content

Closes #15