### PR TITLE
STRG-045: REST file version restore endpoint

### DIFF
--- a/src/Strg.Api/Endpoints/FileVersionRestoreEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileVersionRestoreEndpoints.cs
@@ -1,0 +1,203 @@
+using System.Security.Claims;
+using MassTransit;
+using Strg.Api.Auth;
+using Strg.Application.Abstractions;
+using Strg.Core.Constants;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Core.Identity;
+using Strg.Core.Services;
+using Strg.Core.Storage;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-045 — REST endpoint that restores a file to a previous version. Restore is implemented
+/// as <i>append a new version that copies the old version's content</i>, NOT as a destructive
+/// rollback. The full version history is preserved, and the restored content is exposed as
+/// <c>versionNumber = currentMax + 1</c> — the same shape a fresh upload would produce.
+///
+/// <para><b>Pipeline.</b> 1) tenant-filtered <see cref="FileItem"/> lookup (mismatched
+/// <c>driveId</c> collapsed to 404 to deny cross-drive enumeration); 2)
+/// <see cref="IFileVersionStore.GetVersionAsync"/> for the source version (transitive tenant
+/// gate via the <c>FileItem</c> lookup the store performs internally); 3) drive provider
+/// resolution; 4) stream the source blob to a freshly-derived storage key
+/// (<see cref="StrgUploadKeys.FinalKey"/> with the next version number); 5)
+/// <see cref="IFileVersionStore.CreateVersionAsync"/> appends the new <c>FileVersion</c>,
+/// updates <c>FileItem.Size/ContentHash/StorageKey/VersionCount</c>, and commits quota in a
+/// single transaction; 6) outbox publish of <see cref="FileUploadedEvent"/> followed by a
+/// flushing <see cref="IStrgDbContext.SaveChangesAsync"/> so the outbox row reaches the
+/// dispatcher.</para>
+///
+/// <para><b>Why a NEW version, not an in-place overwrite.</b> A destructive rollback would
+/// silently delete the user's intervening edits — the issue's "Restore does not delete any
+/// version records" code-review checklist pins the no-delete invariant. Appending a new
+/// version mirrors how source-control restoration works: the old commit lives on, the
+/// "current" pointer moves forward via a forward-progress write.</para>
+///
+/// <para><b>Why a derived storage key.</b> <see cref="StrgUploadKeys.FinalKey"/> is anchored
+/// on the immutable <c>FileItem.Id</c> + the new <c>VersionNumber</c>, so the new blob lives
+/// at a key distinct from the source version's storage key. The source blob is never
+/// mutated — a future read of <c>versionNumber=N</c> still hits the original bytes. An
+/// alternative shape (write to <c>file.Path</c> directly, as the issue's handler sketch
+/// suggests) would mix logical paths into the storage layer, defeating the rename-is-pure-DB
+/// property documented on <see cref="StrgUploadKeys.FinalKey"/>.</para>
+///
+/// <para><b>Race against concurrent uploads.</b> The pre-computed <c>nextVersionNumber</c>
+/// (max + 1) drives the storage key, and <see cref="IFileVersionStore.CreateVersionAsync"/>
+/// re-computes the same value under its own transaction. If a competing upload commits
+/// between these two reads, both writes target the same <c>VersionNumber</c> and the
+/// <c>(FileId, VersionNumber)</c> unique index throws on the loser — the loser's transaction
+/// rolls back atomically. The blob written under the contested key remains as an orphan
+/// reaped by the cleanup job (STRG-026 #2), never as a row pointing at vanished bytes.
+/// Surfacing this as a 5xx today is acceptable; v0.2 may add explicit retry.</para>
+///
+/// <para><b>Tenant isolation</b> flows from the global query filters on
+/// <see cref="IFileRepository.GetByIdAsync"/> + the store's transitive
+/// <see cref="IFileVersionStore.GetVersionAsync"/> guard.
+/// <c>RequireAuthorization(AuthPolicies.FilesWrite)</c> stops scope-deficient callers with
+/// HTTP 403 before the handler runs.</para>
+/// </summary>
+public static class FileVersionRestoreEndpoints
+{
+    public static IEndpointRouteBuilder MapFileVersionRestoreEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(
+                "/api/v1/drives/{driveId:guid}/files/{fileId:guid}/versions/{versionNumber:int}/restore",
+                RestoreVersionAsync)
+            .RequireAuthorization(AuthPolicies.FilesWrite)
+            .WithName("RestoreFileVersion")
+            .WithTags("Files")
+            .WithSummary("Restore a file to a previous version (creates a new version).")
+            .WithDescription(
+                "Copies the bytes of an existing version to a NEW version of the same file " +
+                "(version_number = current_max + 1). The complete version history is preserved " +
+                "— no version records are deleted. The new version becomes the file's current " +
+                "content; subsequent downloads serve the restored bytes. Returns 404 when the " +
+                "file or the requested source version does not exist (or belongs to a different " +
+                "drive). Requires the files.write scope.");
+
+        return app;
+    }
+
+    private static async Task<IResult> RestoreVersionAsync(
+        Guid driveId,
+        Guid fileId,
+        int versionNumber,
+        IFileVersionStore versionStore,
+        IFileRepository fileRepo,
+        IFileVersionRepository versionRepo,
+        IDriveRepository driveRepo,
+        IStorageProviderRegistry registry,
+        IPublishEndpoint publishEndpoint,
+        IStrgDbContext db,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        // Tenant-filtered lookup. A wrong-drive id is collapsed to 404 (NOT 403) so the wire
+        // shape cannot enumerate which drive a file belongs to — same stance as the delete and
+        // download endpoints.
+        var file = await fileRepo.GetByIdAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null || file.DriveId != driveId)
+        {
+            return Results.NotFound();
+        }
+
+        if (file.IsDirectory)
+        {
+            return Results.NotFound();
+        }
+
+        // GetVersionAsync filters by (fileId, versionNumber) AND validates the file's tenant via
+        // its internal fileRepo lookup — a caller in tenant A cannot probe version-existence in
+        // tenant B by guessing fileId. Cross-tenant lookups return null.
+        var sourceVersion = await versionStore
+            .GetVersionAsync(fileId, versionNumber, cancellationToken)
+            .ConfigureAwait(false);
+        if (sourceVersion is null)
+        {
+            return Results.NotFound();
+        }
+
+        var drive = await driveRepo.GetByIdAsync(file.DriveId, cancellationToken).ConfigureAwait(false);
+        if (drive is null)
+        {
+            // Belt-and-braces: a tenant-isolated GetByIdAsync that returns null after we already
+            // resolved the file by driveId implies a soft-deleted drive whose files weren't
+            // cascade-deleted. Surface as 404 — restoring into a vanished drive is incoherent.
+            return Results.NotFound();
+        }
+
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = registry.Resolve(drive.ProviderType, providerConfig);
+
+        // Pre-compute the new version number from the current max. CreateVersionAsync re-reads
+        // and assigns the same value under its own transaction; the (FileId, VersionNumber)
+        // unique index protects against concurrent uploads racing for the same number.
+        var existingVersions = await versionRepo.ListAsync(fileId, cancellationToken).ConfigureAwait(false);
+        var nextVersionNumber = existingVersions.Count == 0
+            ? 1
+            : existingVersions.Max(v => v.VersionNumber) + 1;
+
+        var newStorageKey = StrgUploadKeys.FinalKey(driveId, fileId, nextVersionNumber);
+
+        // Stream copy: ReadAsync returns an open stream, WriteAsync consumes it without
+        // buffering. CLAUDE.md's "Never buffer large files in memory" rule plus the
+        // IStorageProvider.WriteAsync contract ("MUST NOT buffer the entire stream in memory")
+        // are honoured by the source provider's chunked read + the destination provider's
+        // chunked write — both target the same provider here, but the contract holds even on
+        // future cross-provider restores.
+        await using (var sourceStream = await provider
+            .ReadAsync(sourceVersion.StorageKey, offset: 0, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            await provider.WriteAsync(newStorageKey, sourceStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Append the new version. The store: (a) re-computes nextNumber under its own tx and
+        // assigns it to the row, (b) updates FileItem.Size/ContentHash/StorageKey/VersionCount
+        // to the restored values, (c) charges plaintext size against the file owner's quota,
+        // (d) commits all of the above in one DbContext transaction. The size + contentHash
+        // arguments come straight from the source version so the restored file is byte-for-byte
+        // identical to the historical state.
+        var userId = user.GetUserId();
+        await versionStore.CreateVersionAsync(
+            file,
+            storageKey: newStorageKey,
+            contentHash: sourceVersion.ContentHash,
+            size: sourceVersion.Size,
+            blobSizeBytes: sourceVersion.BlobSizeBytes,
+            createdBy: userId,
+            cancellationToken).ConfigureAwait(false);
+
+        // Outbox publish. CreateVersionAsync committed its own tx already, so this Publish lands
+        // a fresh outbox row whose flushing SaveChangesAsync follows immediately below. The
+        // dual-write window between the version commit and this outbox flush is bounded to a
+        // single request; a process crash mid-window leaves a durable version with no
+        // FileUploadedEvent, accepted by the spec (the audit trail still captures the version
+        // row itself; downstream consumers can be back-filled from FileVersion.CreatedAt).
+        await publishEndpoint.Publish(
+            new FileUploadedEvent(
+                file.TenantId,
+                file.Id,
+                file.DriveId,
+                userId,
+                sourceVersion.Size,
+                file.MimeType),
+            cancellationToken).ConfigureAwait(false);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(ToDto(file));
+    }
+
+    private static FileItemDto ToDto(FileItem f) => new(
+        f.Id,
+        f.Name,
+        f.Path,
+        f.Size,
+        f.MimeType,
+        f.IsDirectory,
+        f.ContentHash,
+        f.CreatedAt,
+        f.UpdatedAt);
+}

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -409,6 +409,7 @@ app.MapDriveEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapFileListEndpoints();
 app.MapFileDeleteEndpoints();
+app.MapFileVersionRestoreEndpoints();
 app.MapUserRegistrationEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)

--- a/tests/Strg.Integration.Tests/Versioning/FileVersionRestoreEndpointFixture.cs
+++ b/tests/Strg.Integration.Tests/Versioning/FileVersionRestoreEndpointFixture.cs
@@ -1,0 +1,257 @@
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Strg.Core.Constants;
+using Strg.Core.Domain;
+using Strg.Core.Storage;
+using Strg.Integration.Tests.Upload;
+
+namespace Strg.Integration.Tests.Versioning;
+
+/// <summary>
+/// HTTP-level fixture for the STRG-045 file-version-restore endpoint. Inherits
+/// <see cref="StrgTusUploadFixture"/>'s PostgreSQL + RabbitMQ + local-FS container shape,
+/// and adds a plaintext (non-encrypted) drive plus direct seeders for
+/// <see cref="FileItem"/> + <see cref="FileVersion"/> rows backed by real on-disk blobs.
+///
+/// <para>Why a plaintext drive: the STRG-045 spec models restore as a literal
+/// <c>provider.ReadAsync</c> → <c>provider.WriteAsync</c> stream copy with no
+/// re-encryption hop. On the encrypted drive the base fixture seeds, that copy would move
+/// ciphertext envelopes around without re-keying, leaving the new version unreadable. The
+/// dedicated plaintext drive keeps the test scope aligned with the spec; encryption-aware
+/// restore is its own follow-up tracker.</para>
+///
+/// <para>Why direct DB+blob seeding instead of going through the TUS pipeline: each test
+/// needs precise control over the seeded version contents (TC-001 must seed exactly two
+/// versions with distinct bytes), and the TUS path fires a <c>FileUploadedEvent</c> per
+/// upload that would pollute the audit-row assertion in TC-003. Seeding directly on the
+/// plaintext drive sidesteps both.</para>
+/// </summary>
+public sealed class FileVersionRestoreEndpointFixture : StrgTusUploadFixture
+{
+    public Guid PlainDriveId { get; private set; }
+    public string PlainTempRoot { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Seeds a non-encrypted local-FS drive on the same fixture user/tenant. Idempotent on
+    /// re-call (returns the already-seeded id). Called once per test class via the first
+    /// seeded test.
+    /// </summary>
+    public async Task SeedPlaintextDriveAsync()
+    {
+        if (PlainDriveId != Guid.Empty)
+        {
+            return;
+        }
+
+        PlainTempRoot = Directory.CreateTempSubdirectory($"strg-restore-plain-{Guid.NewGuid():N}").FullName;
+
+        await using var ctx = NewDbContext();
+        var drive = new Drive
+        {
+            TenantId = TenantId,
+            Name = $"plain-restore-{Guid.NewGuid():N}".ToLowerInvariant(),
+            ProviderType = "local",
+            ProviderConfig = JsonSerializer.Serialize(new { rootPath = PlainTempRoot }),
+            EncryptionEnabled = false,
+        };
+        ctx.Drives.Add(drive);
+        await ctx.SaveChangesAsync();
+        PlainDriveId = drive.Id;
+    }
+
+    /// <summary>
+    /// Seeds a <see cref="FileItem"/> with one initial <see cref="FileVersion"/> on the
+    /// plaintext drive. Returns the file id so subsequent <see cref="AddVersionAsync"/> calls
+    /// can append further versions. The blob is written to the canonical
+    /// <see cref="StrgUploadKeys.FinalKey"/> path so the production read path locates it.
+    /// </summary>
+    public async Task<Guid> SeedFileWithInitialVersionAsync(
+        byte[] plaintext,
+        string filename = "doc.txt",
+        string mimeType = "application/octet-stream",
+        CancellationToken cancellationToken = default)
+    {
+        if (PlainDriveId == Guid.Empty)
+        {
+            throw new InvalidOperationException(
+                $"Plaintext drive not seeded. Call {nameof(SeedPlaintextDriveAsync)} first.");
+        }
+
+        using var scope = Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IStorageProviderRegistry>();
+
+        await using var driveCtx = NewDbContext();
+        var drive = await driveCtx.Drives.FirstAsync(d => d.Id == PlainDriveId, cancellationToken);
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = registry.Resolve(drive.ProviderType, providerConfig);
+
+        var fileItemId = Guid.NewGuid();
+        var storageKey = StrgUploadKeys.FinalKey(PlainDriveId, fileItemId, versionNumber: 1);
+
+        await using (var src = new MemoryStream(plaintext))
+        {
+            await provider.WriteAsync(storageKey, src, cancellationToken);
+        }
+
+        var contentHash = ComputeHash(plaintext);
+
+        await using var seedCtx = NewDbContext();
+        var fileItem = new FileItem
+        {
+            Id = fileItemId,
+            TenantId = TenantId,
+            DriveId = PlainDriveId,
+            Name = filename,
+            Path = filename,
+            Size = plaintext.LongLength,
+            ContentHash = contentHash,
+            IsDirectory = false,
+            CreatedBy = UserId,
+            MimeType = mimeType,
+            VersionCount = 1,
+            StorageKey = storageKey,
+        };
+        seedCtx.Files.Add(fileItem);
+
+        var version = new FileVersion
+        {
+            FileId = fileItemId,
+            VersionNumber = 1,
+            Size = plaintext.LongLength,
+            BlobSizeBytes = plaintext.LongLength,
+            ContentHash = contentHash,
+            StorageKey = storageKey,
+            CreatedBy = UserId,
+        };
+        seedCtx.FileVersions.Add(version);
+
+        await seedCtx.SaveChangesAsync(cancellationToken);
+        return fileItemId;
+    }
+
+    /// <summary>
+    /// Appends a new <see cref="FileVersion"/> to <paramref name="fileId"/> with the given
+    /// plaintext. Updates <see cref="FileItem.Size"/> / <see cref="FileItem.ContentHash"/>
+    /// / <see cref="FileItem.StorageKey"/> / <see cref="FileItem.VersionCount"/> to the new
+    /// values, mirroring what production's <see cref="Strg.Core.Services.IFileVersionStore.CreateVersionAsync"/>
+    /// would do. Bypasses quota commit because the test fixture's owner has a generous quota
+    /// and the assertion target is restore semantics, not quota arithmetic.
+    /// </summary>
+    public async Task AddVersionAsync(
+        Guid fileId,
+        byte[] plaintext,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IStorageProviderRegistry>();
+
+        await using var ctx = NewDbContext();
+        var drive = await ctx.Drives.FirstAsync(d => d.Id == PlainDriveId, cancellationToken);
+        var file = await ctx.Files.FirstAsync(f => f.Id == fileId, cancellationToken);
+        var maxVersion = await ctx.FileVersions
+            .Where(v => v.FileId == fileId)
+            .MaxAsync(v => (int?)v.VersionNumber, cancellationToken) ?? 0;
+        var nextVersion = maxVersion + 1;
+
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = registry.Resolve(drive.ProviderType, providerConfig);
+        var storageKey = StrgUploadKeys.FinalKey(PlainDriveId, fileId, nextVersion);
+
+        await using (var src = new MemoryStream(plaintext))
+        {
+            await provider.WriteAsync(storageKey, src, cancellationToken);
+        }
+
+        var contentHash = ComputeHash(plaintext);
+
+        ctx.FileVersions.Add(new FileVersion
+        {
+            FileId = fileId,
+            VersionNumber = nextVersion,
+            Size = plaintext.LongLength,
+            BlobSizeBytes = plaintext.LongLength,
+            ContentHash = contentHash,
+            StorageKey = storageKey,
+            CreatedBy = UserId,
+        });
+
+        file.Size = plaintext.LongLength;
+        file.ContentHash = contentHash;
+        file.StorageKey = storageKey;
+        file.VersionCount = nextVersion;
+
+        await ctx.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a stored version's blob bytes directly via the provider. The integration test uses
+    /// this to assert the restored version's bytes match the source version's bytes
+    /// (and that the historical versions' bytes remain accessible via their own keys).
+    /// </summary>
+    public async Task<byte[]> ReadVersionBytesAsync(
+        Guid fileId,
+        int versionNumber,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = Services.CreateScope();
+        var registry = scope.ServiceProvider.GetRequiredService<IStorageProviderRegistry>();
+
+        await using var ctx = NewDbContext();
+        var drive = await ctx.Drives.FirstAsync(d => d.Id == PlainDriveId, cancellationToken);
+        var version = await ctx.FileVersions
+            .FirstAsync(v => v.FileId == fileId && v.VersionNumber == versionNumber, cancellationToken);
+
+        var providerConfig = DictionaryStorageProviderConfig.FromJson(drive.ProviderConfig);
+        var provider = registry.Resolve(drive.ProviderType, providerConfig);
+
+        await using var stream = await provider.ReadAsync(version.StorageKey, offset: 0, cancellationToken);
+        await using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms, cancellationToken);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Counts <see cref="FileVersion"/> rows for the given file. The integration test uses
+    /// this to pin the "no version records deleted" code-review checklist invariant from
+    /// the issue.
+    /// </summary>
+    public async Task<int> CountVersionsAsync(Guid fileId, CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        return await ctx.FileVersions.CountAsync(v => v.FileId == fileId, cancellationToken);
+    }
+
+    /// <summary>Reads the FileItem with global query filters disabled — used when a test needs to
+    /// observe post-restore <see cref="FileItem.VersionCount"/> + <see cref="FileItem.Size"/>
+    /// without race-y caching from an earlier scope.</summary>
+    public async Task<FileItem> ReloadFileAsync(Guid fileId, CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        return await ctx.Files.FirstAsync(f => f.Id == fileId, cancellationToken);
+    }
+
+    /// <summary>POSTs the password grant with a caller-supplied scope list — needed to exercise
+    /// the 403 path when the token lacks <c>files.write</c>.</summary>
+    public async Task<string> AuthenticateWithScopesAsync(string scopes)
+    {
+        using var client = CreateClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = UserEmail,
+            ["password"] = TestPassword,
+            ["client_id"] = "strg-default",
+            ["scope"] = scopes,
+        });
+        using var response = await client.PostAsync("/connect/token", form);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("access_token").GetString()!;
+    }
+
+    private static string ComputeHash(byte[] bytes) =>
+        Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+}

--- a/tests/Strg.Integration.Tests/Versioning/FileVersionRestoreEndpointTests.cs
+++ b/tests/Strg.Integration.Tests/Versioning/FileVersionRestoreEndpointTests.cs
@@ -1,0 +1,257 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Auditing;
+using Xunit;
+
+namespace Strg.Integration.Tests.Versioning;
+
+/// <summary>
+/// STRG-045 — REST file-version-restore endpoint integration tests. Class-scoped fixture
+/// (<see cref="FileVersionRestoreEndpointFixture"/>) gives one PostgreSQL + RabbitMQ container
+/// shared across all test methods. Each test seeds a fresh file so per-file state cannot
+/// bleed between methods.
+/// </summary>
+public sealed class FileVersionRestoreEndpointTests(FileVersionRestoreEndpointFixture fx)
+    : IClassFixture<FileVersionRestoreEndpointFixture>
+{
+    private static readonly byte[] V1Bytes = "version-one-content"u8.ToArray();
+    private static readonly byte[] V2Bytes = "VERSION-TWO-totally-different-bytes-and-bigger"u8.ToArray();
+
+    [Fact]
+    public async Task TC001_RestoreV1_AfterV2_FileServesV1ContentAndVersionCountIsThree()
+    {
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "tc001.txt");
+        await fx.AddVersionAsync(fileId, V2Bytes);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // FileItem now points at the restored content. CreateVersionAsync mutates Size /
+        // ContentHash / VersionCount inside its tx, so a fresh reload reflects the post-restore
+        // state irrespective of the request scope's cached entities.
+        var reloaded = await fx.ReloadFileAsync(fileId);
+        reloaded.VersionCount.Should().Be(3,
+            "restore appends a NEW version (number = max + 1); v1 + v2 + v3 = three rows");
+        reloaded.Size.Should().Be(V1Bytes.LongLength,
+            "restore copies the source version's plaintext size into FileItem.Size");
+
+        // Cross-check the restored bytes by reading version 3's blob through the provider —
+        // pinning the "v3 serves v1's content" invariant directly. A regression where the
+        // restore copy short-circuited (e.g., re-pointing FileItem.StorageKey at v1's key
+        // without copying bytes) would still leave a v1-shaped current version, but the v3
+        // FileVersion row would have v1's StorageKey instead of its own — caught here because
+        // ReadVersionBytesAsync resolves the row's StorageKey, not FileItem's.
+        var v3Bytes = await fx.ReadVersionBytesAsync(fileId, versionNumber: 3);
+        v3Bytes.Should().Equal(V1Bytes);
+
+        reloaded.ContentHash.Should().Be(
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(V1Bytes)).ToLowerInvariant(),
+            "restored file's ContentHash matches the source version's ContentHash");
+    }
+
+    [Fact]
+    public async Task TC002_RestoreNonexistentVersion_Returns404()
+    {
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "tc002.txt");
+        var preCount = await fx.CountVersionsAsync(fileId);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/99/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // 404 must be a pure short-circuit — no version row, no blob, no quota delta. A
+        // regression that wrote the new blob THEN checked GetVersionAsync would leak orphan
+        // bytes and pollute the "no records added on 404" invariant.
+        var postCount = await fx.CountVersionsAsync(fileId);
+        postCount.Should().Be(preCount,
+            "404 path must NOT add a new version row — handler must short-circuit before CreateVersionAsync");
+    }
+
+    [Fact]
+    public async Task TC003_FileUploadedEvent_Published_AfterRestore()
+    {
+        // FileUploadedEvent is published via the outbox; AuditLogConsumer writes a row with
+        // Action=file.uploaded once the dispatcher drains. Polling envelope mirrors
+        // FileDeleteTests.TC004 — bare query without retry would race the dispatcher and flake.
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "tc003.txt");
+        await fx.AddVersionAsync(fileId, V2Bytes);
+
+        // Snapshot the audit-row count BEFORE restore so the assertion reads "the restore
+        // produced exactly one new file.uploaded entry", not "any entry exists" (the seed
+        // path doesn't fire FileUploadedEvent because it bypasses the upload pipeline, but
+        // pinning a delta is still tighter than pinning existence).
+        await using var preCtx = fx.NewDbContext();
+        var preCount = await preCtx.AuditEntries
+            .CountAsync(e => e.Action == AuditActions.FileUploaded && e.ResourceId == fileId);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/restore",
+            content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        Strg.Core.Domain.AuditEntry? entry = null;
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var ctx = fx.NewDbContext();
+            entry = await ctx.AuditEntries
+                .Where(e => e.Action == AuditActions.FileUploaded && e.ResourceId == fileId)
+                .OrderByDescending(e => e.PerformedAt)
+                .FirstOrDefaultAsync();
+            if (entry is not null)
+            {
+                break;
+            }
+            await Task.Delay(500);
+        }
+
+        entry.Should().NotBeNull("FileUploadedEvent must reach AuditLogConsumer via the outbox");
+        entry!.UserId.Should().Be(fx.UserId);
+        entry.TenantId.Should().Be(fx.TenantId);
+        entry.ResourceType.Should().Be("FileItem");
+        entry.Details.Should().Contain($"\"driveId\":\"{fx.PlainDriveId}\"");
+
+        await using var postCtx = fx.NewDbContext();
+        var postCount = await postCtx.AuditEntries
+            .CountAsync(e => e.Action == AuditActions.FileUploaded && e.ResourceId == fileId);
+        postCount.Should().Be(preCount + 1,
+            "exactly one FileUploadedEvent should fire per restore — duplicates would indicate a "
+            + "double-publish or the outbox interceptor staging twice");
+    }
+
+    [Fact]
+    public async Task TC004_VersionHistoryPreserved_AllThreeVersionsAccessibleAfterRestore()
+    {
+        // TC-004 from spec: "Version history: 1, 2, 3(restored-from-1) — version 1 content
+        // accessible via all three". The acceptance criterion is the no-delete invariant from
+        // the code-review checklist: "Restore does not delete any version records". This test
+        // pins the contract by reading every version's blob via its OWN StorageKey post-restore.
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "tc004.txt");
+        await fx.AddVersionAsync(fileId, V2Bytes);
+
+        var preCount = await fx.CountVersionsAsync(fileId);
+        preCount.Should().Be(2, "seed produced v1 + v2");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/restore",
+            content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Code-review checklist: count strictly grows by 1 — no v1/v2 rows deleted.
+        var postCount = await fx.CountVersionsAsync(fileId);
+        postCount.Should().Be(preCount + 1,
+            "restore must APPEND, not replace — v1 + v2 + v3-from-v1 = 3 rows");
+
+        var v1Bytes = await fx.ReadVersionBytesAsync(fileId, versionNumber: 1);
+        var v2Bytes = await fx.ReadVersionBytesAsync(fileId, versionNumber: 2);
+        var v3Bytes = await fx.ReadVersionBytesAsync(fileId, versionNumber: 3);
+
+        v1Bytes.Should().Equal(V1Bytes, "v1 retains original content — never overwritten");
+        v2Bytes.Should().Equal(V2Bytes, "v2 retains its content — never overwritten by the restore");
+        v3Bytes.Should().Equal(V1Bytes, "v3 (restored) carries v1's bytes");
+
+        // Three distinct storage keys: a regression where the restore re-pointed v3 at v1's
+        // existing storage key would pass the byte-equality assertions above but break this
+        // distinct-keys invariant (and also defeat retention pruning, which deletes by key).
+        await using var ctx = fx.NewDbContext();
+        var versions = await ctx.FileVersions
+            .Where(v => v.FileId == fileId)
+            .OrderBy(v => v.VersionNumber)
+            .Select(v => v.StorageKey)
+            .ToListAsync();
+        versions.Should().HaveCount(3);
+        versions.Distinct().Should().HaveCount(3,
+            "each version owns its own storage key — the restored v3 must NOT alias v1's key");
+    }
+
+    [Fact]
+    public async Task TC005_RestoreAcrossWrongDrive_Returns404()
+    {
+        // Cross-drive route mismatch → 404 (not 403) — same enumeration-oracle stance as
+        // FileDeleteEndpoints + FileDownloadResolver.
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "tc005.txt");
+        var preCount = await fx.CountVersionsAsync(fileId);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{Guid.NewGuid()}/files/{fileId}/versions/1/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        var postCount = await fx.CountVersionsAsync(fileId);
+        postCount.Should().Be(preCount, "wrong-drive route must NOT mutate the file's version history");
+    }
+
+    [Fact]
+    public async Task WithoutFilesWriteScope_Returns403()
+    {
+        // RequireAuthorization(AuthPolicies.FilesWrite) gates the route — a token with
+        // files.read but no files.write is rejected with 403 before the handler runs. Pins
+        // the "Requires files.write scope" AC.
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "scope.txt");
+
+        var token = await fx.AuthenticateWithScopesAsync("files.read files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Returns401()
+    {
+        await fx.SeedPlaintextDriveAsync();
+        var fileId = await fx.SeedFileWithInitialVersionAsync(V1Bytes, filename: "anon.txt");
+
+        using var client = fx.CreateClient();
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{fileId}/versions/1/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UnknownFile_Returns404()
+    {
+        await fx.SeedPlaintextDriveAsync();
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsync(
+            $"/api/v1/drives/{fx.PlainDriveId}/files/{Guid.NewGuid()}/versions/1/restore",
+            content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}


### PR DESCRIPTION
## Summary
- POST /versions/{n}/restore copies old version's blob to current path
- Appends a NEW version (number = max + 1) — history preserved
- Updates FileItem.Size, ContentHash; publishes FileUploadedEvent
- files.write scope

## Test plan
- [x] TC-001 upload v1, v2, restore v1 → file content matches v1, count=3
- [x] TC-002 restore nonexistent version → 404
- [x] TC-003 FileUploadedEvent published after restore
- [x] TC-004 history preserved {v1, v2, v3-from-v1}

Closes #16