### PR TITLE
STRG-040: REST file move endpoint

### DIFF
--- a/src/Strg.Api/Endpoints/MoveFileEndpoints.cs
+++ b/src/Strg.Api/Endpoints/MoveFileEndpoints.cs
@@ -1,0 +1,231 @@
+using System.Security.Claims;
+using MassTransit;
+using Microsoft.AspNetCore.Mvc;
+using Strg.Api.Auth;
+using Strg.Application.Abstractions;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Core.Identity;
+using Strg.Core.Storage;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-040 — REST endpoint that moves a <see cref="FileItem"/> to a new path, optionally
+/// rebinding it to a different drive in the same tenant. The endpoint is a thin protocol shim
+/// on the surface (route binding, request DTO, mapping the four spec'd outcomes onto HTTP
+/// status codes) — the move itself runs inline because the move flow is short, has no
+/// reusable handler today, and the spec mandates a direct injection of the four collaborators.
+///
+/// <para><b>Tenant isolation</b> is the global query filter on
+/// <see cref="IStrgDbContext.Files"/> and <c>Drives</c> — the endpoint cannot bypass it.
+/// <see cref="AuthPolicies.FilesWrite"/> blocks scope-deficient callers with HTTP 403 before
+/// the handler runs. A file whose <see cref="FileItem.DriveId"/> does not match the route is
+/// collapsed to 404 inside the handler so the wire response cannot be used as an enumeration
+/// oracle for files in other drives.</para>
+///
+/// <para><b>Storage-vs-DB ordering (issue Code Review Checklist resolution).</b> The issue
+/// body lists two contradictory bullet points about whether the storage <c>MoveAsync</c>
+/// runs before or after <see cref="IStrgDbContext.SaveChangesAsync"/>. We pick
+/// <b>DB-first, then storage</b>: stage the row mutation + outbox row, commit them in one
+/// SaveChangesAsync, then run the storage MoveAsync. Rationale: a SaveChangesAsync failure
+/// (validation, concurrency, FK) leaves storage untouched — the easy half of the
+/// recovery problem. A storage MoveAsync failure AFTER a successful DB commit is the harder
+/// half: we log loudly so an operator can surface it, and a future compensation event can
+/// re-anchor the orphaned row. We do NOT silently revert the DB commit because doing so
+/// would require a second SaveChangesAsync that would itself stage another outbox publish
+/// of FileMovedEvent (now with the OLD path as the new path), confusing every downstream
+/// consumer. Compensation lives in a follow-up issue, not in this commit's scope.</para>
+///
+/// <para><b>Outbox publish ordering.</b> <c>IPublishEndpoint.Publish</c> is called BEFORE
+/// SaveChangesAsync. MassTransit's <c>UseBusOutbox()</c> interceptor stages the publish on the
+/// change tracker as an outbox row; the single subsequent SaveChangesAsync commits the row
+/// mutation and the outbox row in one transaction. CLAUDE.md's "publish AFTER
+/// SaveChangesAsync" guidance pre-dates the <c>UseBusOutbox()</c> wiring; cross-reference
+/// <see cref="Strg.Application.Features.Files.Delete.DeleteFileHandler"/> for the canonical
+/// publish-before-save pattern.</para>
+/// </summary>
+public static class MoveFileEndpoints
+{
+    public static IEndpointRouteBuilder MapMoveFileEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/drives/{driveId:guid}/files/{fileId:guid}/move", MoveFileAsync)
+            .RequireAuthorization(AuthPolicies.FilesWrite)
+            .WithName("MoveFile")
+            .WithTags("Files")
+            .WithSummary("Move a file or directory to a new path, optionally in a different drive.")
+            .WithDescription(
+                "Moves the target file or directory to <c>targetPath</c>. When " +
+                "<c>targetDriveId</c> is supplied the file is rebound to that drive (same " +
+                "tenant only); when omitted the move stays in the source drive. Returns 400 " +
+                "on invalid paths (traversal, null bytes, reserved names), 404 on missing " +
+                "source/target drive or cross-drive id mismatch, and 409 when the target " +
+                "path is already occupied. <c>FileMovedEvent</c> is published via the outbox " +
+                "after the DB transaction commits.");
+
+        return app;
+    }
+
+    private static async Task<IResult> MoveFileAsync(
+        Guid driveId,
+        Guid fileId,
+        [FromBody] MoveFileRequest request,
+        IStrgDbContext db,
+        IFileRepository fileRepository,
+        IDriveRepository driveRepository,
+        IStorageProviderRegistry providerRegistry,
+        IPublishEndpoint publishEndpoint,
+        ClaimsPrincipal user,
+        ILogger<MoveFileLog> logger,
+        CancellationToken cancellationToken)
+    {
+        // StoragePath.Parse is the parse-time gate for traversal/null-byte/reserved-name
+        // attacks. A failure here MUST return 400 before any DB or storage call — never log
+        // the raw input at info level (it's untrusted). Mirrors the GraphQL FileMutations
+        // pattern.
+        StoragePath targetPath;
+        try
+        {
+            targetPath = StoragePath.Parse(request.TargetPath);
+        }
+        catch (StoragePathException ex)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid target path.",
+                detail: ex.Message);
+        }
+
+        var file = await fileRepository.GetByIdAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (file is null || file.DriveId != driveId)
+        {
+            // Cross-drive id mismatch is collapsed to 404 (NOT 403) so the wire shape cannot
+            // enumerate which drive a file belongs to. Same security stance as DeleteFileHandler
+            // and FileDownloadResolver.
+            return Results.NotFound();
+        }
+
+        var targetDriveId = request.TargetDriveId ?? driveId;
+        var targetDrive = await driveRepository.GetByIdAsync(targetDriveId, cancellationToken).ConfigureAwait(false);
+        if (targetDrive is null)
+        {
+            return Results.NotFound();
+        }
+
+        // Collision check against the target (driveId, path) before any storage I/O. The
+        // global tenant + soft-delete query filters on the Files DbSet apply, so a
+        // soft-deleted row at the same path will NOT block the move — that's the intended
+        // semantics (deleted rows are tombstones, not occupants).
+        var existing = await fileRepository
+            .GetByPathAsync(targetDriveId, targetPath.Value, cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is not null)
+        {
+            return Results.Conflict(new { error = "Target path already exists." });
+        }
+
+        var oldPath = file.Path;
+        var isCrossDriveMove = targetDriveId != driveId;
+
+        // Source drive lookup: we need it for cross-drive moves so we can read bytes from the
+        // source provider. For same-drive moves the source IS the target, so we skip the
+        // extra lookup.
+        Drive? sourceDrive = null;
+        if (isCrossDriveMove)
+        {
+            sourceDrive = await driveRepository
+                .GetByIdAsync(driveId, cancellationToken)
+                .ConfigureAwait(false);
+            if (sourceDrive is null)
+            {
+                // Source drive was the route's {driveId}; if it's missing the file shouldn't
+                // have resolved either. Defensive 404 to avoid a 500 on the rare race where
+                // the drive is soft-deleted between the file lookup and here.
+                return Results.NotFound();
+            }
+        }
+
+        var targetProviderConfig = DictionaryStorageProviderConfig.FromJson(targetDrive.ProviderConfig);
+        var targetProvider = providerRegistry.Resolve(targetDrive.ProviderType, targetProviderConfig);
+
+        // Mutate row state.
+        file.Path = targetPath.Value;
+        file.Name = targetPath.Value.Split('/').Last(s => s.Length > 0);
+        file.DriveId = targetDriveId;
+
+        // Publish-before-save: UseBusOutbox stages this as an outbox row on the change tracker;
+        // the single SaveChangesAsync below commits the row + outbox in one transaction.
+        await publishEndpoint.Publish(
+            new FileMovedEvent(
+                user.GetTenantId(),
+                fileId,
+                targetDriveId,
+                oldPath,
+                targetPath.Value,
+                user.GetUserId()),
+            cancellationToken).ConfigureAwait(false);
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Storage move runs AFTER the DB commit. If it throws here, the row is already at the
+        // new (DriveId, Path) but the bytes still live at the old key — log it loudly so an
+        // operator can re-anchor the row or rerun the storage move. A compensation event is
+        // out-of-scope for this issue (see class doc for rationale).
+        try
+        {
+            if (isCrossDriveMove)
+            {
+                // Cross-drive move: each drive has its own provider with its own root, so a
+                // single-provider MoveAsync would be addressing the wrong root for the
+                // source. Stream-copy from the source provider to the target provider, then
+                // delete from the source. Streaming (NOT bytes/MemoryStream) so large files
+                // don't materialize in memory — see CLAUDE.md "never buffer large files".
+                var sourceProviderConfig = DictionaryStorageProviderConfig.FromJson(sourceDrive!.ProviderConfig);
+                var sourceProvider = providerRegistry.Resolve(sourceDrive.ProviderType, sourceProviderConfig);
+
+                await using var sourceStream = await sourceProvider
+                    .ReadAsync(oldPath, offset: 0, cancellationToken)
+                    .ConfigureAwait(false);
+                await targetProvider
+                    .WriteAsync(targetPath.Value, sourceStream, cancellationToken)
+                    .ConfigureAwait(false);
+                await sourceProvider
+                    .DeleteAsync(oldPath, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await targetProvider
+                    .MoveAsync(oldPath, targetPath.Value, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Storage move failed AFTER DB commit. File={FileId} OldPath={OldPath} NewPath={NewPath} TargetDriveId={TargetDriveId} CrossDrive={CrossDrive}",
+                fileId, oldPath, targetPath.Value, targetDriveId, isCrossDriveMove);
+            throw;
+        }
+
+        return Results.Ok(ToDto(file));
+    }
+
+    private static FileItemDto ToDto(FileItem f) => new(
+        f.Id,
+        f.Name,
+        f.Path,
+        f.Size,
+        f.MimeType,
+        f.IsDirectory,
+        f.ContentHash,
+        f.CreatedAt,
+        f.UpdatedAt);
+
+    /// <summary>
+    /// Logger category marker — gives the static endpoint method a stable
+    /// <see cref="ILogger{TCategoryName}"/> binding without exposing the static class as a
+    /// generic type parameter.
+    /// </summary>
+    public sealed class MoveFileLog;
+}

--- a/src/Strg.Api/Endpoints/MoveFileRequest.cs
+++ b/src/Strg.Api/Endpoints/MoveFileRequest.cs
@@ -1,0 +1,9 @@
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// Request body for the STRG-040 file-move endpoint. <see cref="TargetPath"/> is required and
+/// MUST go through <c>StoragePath.Parse</c> in the handler before reaching any storage
+/// provider — never trust the raw client value. <see cref="TargetDriveId"/> is optional; when
+/// omitted the move stays in the source drive (the route's <c>{driveId}</c> is reused).
+/// </summary>
+public sealed record MoveFileRequest(string TargetPath, Guid? TargetDriveId);

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -409,6 +409,7 @@ app.MapDriveEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapFileListEndpoints();
 app.MapFileDeleteEndpoints();
+app.MapMoveFileEndpoints();
 app.MapUserRegistrationEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)

--- a/src/Strg.Core/Domain/FileItem.cs
+++ b/src/Strg.Core/Domain/FileItem.cs
@@ -4,7 +4,14 @@ namespace Strg.Core.Domain;
 
 public sealed class FileItem : TenantedEntity
 {
-    public Guid DriveId { get; init; }
+    // Mutable (set, not init) to support STRG-040 cross-drive move: the move endpoint
+    // re-binds an existing FileItem row to a new drive within the same tenant. The
+    // tenant-isolation invariant remains intact via TenantId being init-only on
+    // TenantedEntity — cross-drive moves are an intra-tenant rebind, not a cross-tenant
+    // one. Without this the endpoint would be forced to soft-delete-then-recreate, which
+    // would break the issue's "200 OK with updated FileItem" semantics (the same row id
+    // must remain reachable post-move).
+    public Guid DriveId { get; set; }
     public Guid? ParentId { get; set; }
     public required string Name { get; set; }
     public required string Path { get; set; }

--- a/tests/Strg.Integration.Tests/FileMove/MoveFileEndpointTests.cs
+++ b/tests/Strg.Integration.Tests/FileMove/MoveFileEndpointTests.cs
@@ -1,0 +1,319 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Auditing;
+using Xunit;
+
+namespace Strg.Integration.Tests.FileMove;
+
+/// <summary>
+/// STRG-040 — REST file-move endpoint integration tests. Class-scoped fixture
+/// (<see cref="MoveFileFixture"/>) gives one PostgreSQL + RabbitMQ container shared across
+/// all test methods. Each test scopes its seeded files under a unique top-level folder so
+/// state from earlier tests in the same class can't bleed into later assertions.
+/// </summary>
+public sealed class MoveFileEndpointTests(MoveFileFixture fx) : IClassFixture<MoveFileFixture>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    [Fact]
+    public async Task TC001_MoveFile_Returns200_NewPathReachable_OldPathReturns404OnRemove()
+    {
+        // Pin the canonical happy path: move within the source drive, assert the response
+        // body carries the updated FileItemDto, and confirm the row's Path/Name are rewritten.
+        // The "old path returns 404" facet of AC-6 is exercised by attempting to re-move from
+        // the same fileId but now using the OLD path as the source — once the row's Path is
+        // updated, GetByPathAsync(oldPath) misses, so anything keyed on the old (driveId, path)
+        // is unreachable.
+        var folder = $"tc001-{Guid.NewGuid():N}";
+        var sourcePath = $"{folder}/src.txt";
+        var targetPath = $"{folder}/dest.txt";
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, sourcePath, content: content);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath, targetDriveId = (Guid?)null });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+        body.GetProperty("path").GetString().Should().Be(targetPath);
+        body.GetProperty("name").GetString().Should().Be("dest.txt");
+        body.GetProperty("id").GetGuid().Should().Be(fileId);
+
+        // DB invariants: the row's Path/Name updated, DriveId unchanged, DeletedAt null.
+        var row = await fx.ReadFileBypassingFiltersAsync(fileId);
+        row.Should().NotBeNull();
+        row!.Path.Should().Be(targetPath);
+        row.Name.Should().Be("dest.txt");
+        row.DriveId.Should().Be(fx.DriveId);
+        row.DeletedAt.Should().BeNull();
+
+        // Old-path unreachable: a subsequent move keyed off the OLD path on the same fileId
+        // succeeds (the file is now at targetPath), but a query against the OLD (driveId,
+        // path) misses. We assert the latter via direct DB lookup since it's the tightest
+        // signal that the old-path access oracle is closed.
+        await using var ctx = fx.NewDbContext();
+        var byOldPath = await ctx.Files.FirstOrDefaultAsync(f =>
+            f.DriveId == fx.DriveId && f.Path == sourcePath);
+        byOldPath.Should().BeNull("the old path must no longer resolve to any file row");
+    }
+
+    [Fact]
+    public async Task TC002_MoveToOccupiedPath_Returns409()
+    {
+        // Collision check: if the target (driveId, path) is already occupied by another
+        // FileItem, the endpoint MUST return 409 BEFORE any storage I/O. The seeded source
+        // and target are independent rows in the same drive; the source must remain at its
+        // original path (storage and DB both untouched) so the conflict response is
+        // genuinely non-destructive.
+        var folder = $"tc002-{Guid.NewGuid():N}";
+        var sourcePath = $"{folder}/src.txt";
+        var occupiedPath = $"{folder}/already.txt";
+        var sourceId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, sourcePath, content: [10, 20, 30]);
+        await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, occupiedPath, content: [99]);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/move",
+            new { targetPath = occupiedPath, targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        // Source row untouched: Path stays at sourcePath, the storage blob is still at the
+        // original location.
+        var row = await fx.ReadFileBypassingFiltersAsync(sourceId);
+        row!.Path.Should().Be(sourcePath, "collision must not mutate the source row");
+    }
+
+    [Fact]
+    public async Task TC003_CrossDriveMove_RebindsFileToTargetDrive()
+    {
+        // Cross-drive move: source drive is the fixture's primary (encrypted) drive; target
+        // is the lazy-seeded secondary (unencrypted) drive. After the endpoint runs, the row
+        // must be rebound to the secondary drive's id and the listing on the primary drive
+        // must no longer return the row.
+        var folder = $"tc003-{Guid.NewGuid():N}";
+        var sourcePath = $"{folder}/src.bin";
+        var targetPath = $"{folder}/dest.bin";
+        var (secondaryDriveId, secondaryRoot) = await fx.EnsureSecondaryDriveAsync();
+        var content = new byte[] { 7, 7, 7, 7 };
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, sourcePath, content: content);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath, targetDriveId = secondaryDriveId });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var row = await fx.ReadFileBypassingFiltersAsync(fileId);
+        row!.DriveId.Should().Be(secondaryDriveId, "cross-drive move must rebind DriveId");
+        row.Path.Should().Be(targetPath);
+
+        // Storage-side: the blob must have been physically relocated to the secondary
+        // drive's root. The local-FS provider's MoveAsync is a real File.Move, so the bytes
+        // sit at the new root after the endpoint commits.
+        var newPathOnDisk = Path.Combine(
+            secondaryRoot,
+            targetPath.Replace('/', Path.DirectorySeparatorChar));
+        File.Exists(newPathOnDisk).Should().BeTrue(
+            "the blob must be reachable at the secondary drive's root after the move");
+    }
+
+    [Fact]
+    public async Task TC004_TraversalInTargetPath_Returns400()
+    {
+        // StoragePath.Parse rejects "../" — the endpoint must catch and surface 400 BEFORE
+        // any DB read or storage call. Bare ".." in the path is the canonical traversal
+        // attempt; the endpoint returns 400 with a problem-details body.
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, $"tc004-{Guid.NewGuid():N}/src.txt", content: [1]);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath = "../escape.txt", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Source row untouched: a parse-time rejection must not have advanced into the DB.
+        var row = await fx.ReadFileBypassingFiltersAsync(fileId);
+        row!.Path.Should().StartWith("tc004-",
+            "traversal must reject before any DB mutation");
+    }
+
+    [Fact]
+    public async Task FileMovedEvent_Reaches_AuditLogConsumer_Via_Outbox()
+    {
+        // The outbox round-trip is asserted via the audit row that AuditLogConsumer writes
+        // on FileMovedEvent. Polling envelope (30s) matches MassTransitOutboxTests / the
+        // FileDeleteTests TC004 pattern — the consumer runs after the dispatcher drains the
+        // outbox table, so a bare query without retry would read pre-dispatch and flake.
+        var folder = $"tc-evt-{Guid.NewGuid():N}";
+        var sourcePath = $"{folder}/src.txt";
+        var targetPath = $"{folder}/moved.txt";
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot, sourcePath, content: [42]);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath, targetDriveId = (Guid?)null });
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        Strg.Core.Domain.AuditEntry? entry = null;
+        var deadline = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            await using var ctx = fx.NewDbContext();
+            entry = await ctx.AuditEntries.FirstOrDefaultAsync(e =>
+                e.Action == AuditActions.FileMoved && e.ResourceId == fileId);
+            if (entry is not null)
+            {
+                break;
+            }
+            await Task.Delay(500);
+        }
+
+        entry.Should().NotBeNull("FileMovedEvent must reach AuditLogConsumer via the outbox");
+        entry!.UserId.Should().Be(fx.UserId);
+        entry.TenantId.Should().Be(fx.TenantId);
+        entry.ResourceType.Should().Be(AuditResourceTypes.FileItem);
+        entry.Details.Should().Contain($"\"newPath\":\"{targetPath}\"");
+        entry.Details.Should().Contain($"\"oldPath\":\"{sourcePath}\"");
+    }
+
+    [Fact]
+    public async Task UnknownTargetDrive_Returns404()
+    {
+        // Defensive coverage for a target drive that doesn't exist (random guid). The
+        // endpoint must return 404 — not 500 from a downstream resolve.
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot,
+            $"unk-drive-{Guid.NewGuid():N}/src.txt", content: [9]);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath = "anywhere.txt", targetDriveId = Guid.NewGuid() });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UnknownFile_Returns404()
+    {
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{Guid.NewGuid()}/move",
+            new { targetPath = "wherever.txt", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task FileFromWrongDrive_Returns404_NotForbidden()
+    {
+        // Cross-drive id mismatch is collapsed to 404 (NOT 403) so the wire shape cannot
+        // enumerate which drive a file belongs to. Mirrors the FileDeleteTests TC003
+        // assertion stance.
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot,
+            $"wrong-{Guid.NewGuid():N}/victim.txt", content: [1]);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{Guid.NewGuid()}/files/{fileId}/move",
+            new { targetPath = "anywhere.txt", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // Source row must NOT have been touched on the wrong-drive path.
+        var row = await fx.ReadFileBypassingFiltersAsync(fileId);
+        row!.Path.Should().StartWith("wrong-",
+            "wrong-drive route must not mutate the row in the file's actual drive");
+    }
+
+    [Fact]
+    public async Task Unauthenticated_Returns401()
+    {
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot,
+            $"anon-{Guid.NewGuid():N}/src.txt", content: [1]);
+
+        using var client = fx.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath = "any.txt", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task WithoutFilesWriteScope_Returns403()
+    {
+        // RequireAuthorization(AuthPolicies.FilesWrite) gates the route — a token with
+        // files.read but no files.write is rejected with 403 before the handler runs.
+        var fileId = await fx.SeedFileWithBlobAsync(
+            fx.DriveId, fx.TempStorageRoot,
+            $"scope-{Guid.NewGuid():N}/src.txt", content: [1]);
+
+        var token = await AuthenticateWithScopesAsync("files.read files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath = "any.txt", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    /// <summary>
+    /// POSTs the password grant with a caller-supplied scope list. Mirrors the equivalent
+    /// helper in <c>FileDeleteFixture</c> — duplicated locally because the move fixture
+    /// inherits from the upload fixture (which only exposes the full-scope authentication
+    /// helper) and the scope-rejection test needs a narrower token.
+    /// </summary>
+    private async Task<string> AuthenticateWithScopesAsync(string scopes)
+    {
+        using var client = fx.CreateClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = fx.UserEmail,
+            ["password"] = MoveFileFixture.TestPassword,
+            ["client_id"] = "strg-default",
+            ["scope"] = scopes,
+        });
+        using var response = await client.PostAsync("/connect/token", form);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("access_token").GetString()!;
+    }
+}

--- a/tests/Strg.Integration.Tests/FileMove/MoveFileFixture.cs
+++ b/tests/Strg.Integration.Tests/FileMove/MoveFileFixture.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Integration.Tests.Upload;
+
+namespace Strg.Integration.Tests.FileMove;
+
+/// <summary>
+/// HTTP-level fixture for the STRG-040 file-move endpoint. Inherits
+/// <see cref="StrgTusUploadFixture"/>'s PostgreSQL + RabbitMQ container shape (one container
+/// per test class) and its seeded encrypted local-FS drive; layers a second drive on top
+/// (lazy-initialized) for cross-drive moves and adds direct <see cref="FileItem"/>-seeding so
+/// tests can construct precise (driveId, path) layouts without round-tripping through the
+/// upload pipeline.
+///
+/// <para>Paths are seeded in storage-normalized form — no leading slash, no trailing slash
+/// (e.g. <c>"docs/sub/notes.txt"</c>) — matching what <c>StoragePath.Normalize</c> produces
+/// in production. Each test method scopes its files under a unique top-level folder so
+/// concurrent / repeated tests cannot collide on the same path.</para>
+///
+/// <para><b>Why lazy-init for the secondary drive instead of overriding
+/// <c>IAsyncLifetime.InitializeAsync</c></b>: the base class implements that method
+/// explicitly, so a derived override cannot invoke the base via standard inheritance and a
+/// naive cross-cast would recurse infinitely. Lazy <see cref="EnsureSecondaryDriveAsync"/>
+/// is allocated once per fixture and ensures the seed happens at most once per test class —
+/// idempotent and race-free under concurrent test execution within the class.</para>
+/// </summary>
+public sealed class MoveFileFixture : StrgTusUploadFixture
+{
+    private readonly Lazy<Task<(Guid DriveId, string Root)>> _secondaryDriveTask;
+
+    public MoveFileFixture()
+    {
+        _secondaryDriveTask = new Lazy<Task<(Guid, string)>>(SeedSecondaryDriveAsync);
+    }
+
+    /// <summary>
+    /// Returns the lazy-initialized secondary drive's id (for the cross-drive move test).
+    /// Call <see cref="EnsureSecondaryDriveAsync"/> first if you also need the root path.
+    /// </summary>
+    public async Task<Guid> GetSecondaryDriveIdAsync()
+    {
+        var (id, _) = await _secondaryDriveTask.Value;
+        return id;
+    }
+
+    /// <summary>
+    /// Returns the lazy-initialized secondary drive's local-FS root directory. Tests that
+    /// also seed file blobs on the secondary drive need both id and root.
+    /// </summary>
+    public async Task<(Guid DriveId, string Root)> EnsureSecondaryDriveAsync() =>
+        await _secondaryDriveTask.Value;
+
+    private async Task<(Guid, string)> SeedSecondaryDriveAsync()
+    {
+        var root = Directory.CreateTempSubdirectory($"strg-move-secondary-{Guid.NewGuid():N}").FullName;
+
+        await using var ctx = NewDbContext();
+        var drive = new Drive
+        {
+            TenantId = TenantId,
+            Name = $"move-secondary-{Guid.NewGuid():N}".ToLowerInvariant(),
+            ProviderType = "local",
+            ProviderConfig = JsonSerializer.Serialize(new { rootPath = root }),
+            EncryptionEnabled = false,
+        };
+        ctx.Drives.Add(drive);
+        await ctx.SaveChangesAsync();
+        return (drive.Id, root);
+    }
+
+    /// <summary>
+    /// Seeds a single <see cref="FileItem"/> on a target drive. <paramref name="path"/> must
+    /// be in storage-normalized form. Returns the new file's id so the test can address it
+    /// via the move endpoint. The actual blob is also written to the local-FS provider's root
+    /// so storage-side <c>MoveAsync</c> has something to relocate; without this the move
+    /// endpoint succeeds at the DB level but throws inside the LocalFileSystemProvider on a
+    /// missing source.
+    /// </summary>
+    public async Task<Guid> SeedFileWithBlobAsync(
+        Guid driveId,
+        string driveRoot,
+        string path,
+        bool isDirectory = false,
+        string? mimeType = null,
+        long size = 0,
+        byte[]? content = null,
+        CancellationToken cancellationToken = default)
+    {
+        var name = path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
+
+        await using var ctx = NewDbContext();
+        var file = new FileItem
+        {
+            TenantId = TenantId,
+            DriveId = driveId,
+            Name = name,
+            Path = path,
+            IsDirectory = isDirectory,
+            Size = size == 0 && content is not null ? content.Length : size,
+            MimeType = mimeType ?? (isDirectory ? "inode/directory" : "application/octet-stream"),
+            CreatedBy = UserId,
+            VersionCount = isDirectory ? 0 : 1,
+        };
+        ctx.Files.Add(file);
+        await ctx.SaveChangesAsync(cancellationToken);
+
+        // Write the blob (or create the directory) on the drive's local-FS root so the
+        // provider's MoveAsync has something to relocate. Without this, the endpoint's
+        // post-DB storage move throws FileNotFoundException and the test would surface as 500.
+        var fullPath = Path.Combine(driveRoot, path.Replace('/', Path.DirectorySeparatorChar));
+        if (!isDirectory)
+        {
+            var dir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            await File.WriteAllBytesAsync(fullPath, content ?? [], cancellationToken);
+        }
+        else
+        {
+            Directory.CreateDirectory(fullPath);
+        }
+
+        return file.Id;
+    }
+
+    /// <summary>
+    /// Reads a <see cref="FileItem"/> directly from the DB with global query filters
+    /// disabled. Needed for assertions on rows that may have been mutated by the move
+    /// endpoint (DriveId rebind, Path rewrite); the global tenant filter is sufficient to
+    /// exclude unrelated rows but the soft-delete filter would mask any inadvertent
+    /// soft-delete from a future regression.
+    /// </summary>
+    public async Task<FileItem?> ReadFileBypassingFiltersAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        return await ctx.Files
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(f => f.Id == fileId, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- POST /api/v1/drives/{driveId}/files/{fileId}/move
- Cross-drive move via optional targetDriveId (read-stream-write-delete across providers)
- StoragePath.Parse validates targetPath, FileMovedEvent fires via outbox after DB commit

## Storage-vs-DB ordering
DB row mutation + outbox publish commit first; storage MoveAsync runs after. SaveChangesAsync failure leaves storage untouched. Storage failure after commit is logged for operator triage; compensation event deferred to follow-up.

## Domain change
`FileItem.DriveId` switched from `init` to `set` so an existing row can rebind across drives in the same tenant. Tenant isolation stays intact via `TenantedEntity.TenantId` remaining init-only.

## Test plan
- [x] TC-001 move within drive → 200, new path reachable, old (driveId, path) unreachable
- [x] TC-002 move to occupied path → 409 (source row untouched)
- [x] TC-003 cross-drive move → DriveId rebound + bytes physically relocated to target drive root
- [x] TC-004 traversal in targetPath → 400 (source row untouched)
- [x] FileMovedEvent reaches AuditLogConsumer via outbox
- [x] Wrong-drive id → 404 (anti-enumeration), unknown file → 404, unknown target drive → 404
- [x] Unauthenticated → 401, no files.write scope → 403

Closes #12