### PR TITLE
STRG-041: REST file copy endpoint

### DIFF
--- a/src/Strg.Api/Endpoints/CopyFileEndpoints.cs
+++ b/src/Strg.Api/Endpoints/CopyFileEndpoints.cs
@@ -1,0 +1,438 @@
+using System.Security.Claims;
+using MassTransit;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Strg.Api.Auth;
+using Strg.Application.Abstractions;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Core.Exceptions;
+using Strg.Core.Identity;
+using Strg.Core.Services;
+using Strg.Core.Storage;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-041 — REST endpoint that copies a file inside the same drive or to a different drive
+/// owned by the caller's tenant. The handler creates a fresh <see cref="FileItem"/> (new
+/// <see cref="Guid"/>), a <see cref="FileVersion"/> at version 1, copies the storage blob via
+/// the per-drive <see cref="IStorageProvider"/>, commits quota, and publishes
+/// <see cref="FileUploadedEvent"/> through the MassTransit outbox.
+///
+/// <para><b>Quota flow (Commit-as-reservation, single-phase per STRG-032).</b> The order is:
+/// <list type="number">
+/// <item>Pre-flight <see cref="IQuotaService.CheckAsync"/> — advisory; surfaces 507 to the
+/// caller before we open a tx so the early-rejection path is cheap and matches the AC's
+/// "quota checked before copy" intent.</item>
+/// <item><see cref="IQuotaService.CommitAsync"/> — atomic gate. Two racing copies against the
+/// same budget cannot both pass; the loser throws <see cref="QuotaExceededException"/> and
+/// short-circuits before any storage I/O.</item>
+/// <item><see cref="IStorageProvider.CopyAsync"/> — the physical bytes-on-disk copy.</item>
+/// <item>On storage failure → <see cref="IQuotaService.ReleaseAsync"/> compensation. Without
+/// this, a crashed CopyAsync would leak quota: bytes were charged at Commit but no FileVersion
+/// row exists to link them to.</item>
+/// <item>DB rows + outbox event staged on the change tracker, flushed atomically by a single
+/// <see cref="IStrgDbContext.SaveChangesAsync"/>. Publish-before-Save is the canonical
+/// MassTransit <c>UseBusOutbox</c> ordering — see <c>DeleteFileHandler</c> for the same
+/// pattern; CLAUDE.md's "publish AFTER" guidance pre-dates the interceptor wiring.</item>
+/// </list></para>
+///
+/// <para><b>Tenant isolation.</b> The global query filter on <c>StrgDbContext.Files</c> /
+/// <c>StrgDbContext.Drives</c> enforces tenant scope on every read. A caller addressing a file
+/// they cannot see (different tenant, soft-deleted) returns 404 collapsed — no enumeration
+/// oracle, identical wire shape to "file does not exist".</para>
+///
+/// <para><b>Cross-drive ownership.</b> Both source and target drive must belong to the caller's
+/// tenant. Source ownership is gated by the route's <c>{driveId}</c> + the source FileItem's
+/// own DriveId match (collapsed to 404 on mismatch); target ownership flows from
+/// <see cref="IDriveRepository.GetByIdAsync"/>, which honours the global tenant filter.</para>
+///
+/// <para><b>Path safety.</b> User-supplied <c>TargetPath</c> goes through
+/// <see cref="StoragePath.Parse"/> before any storage call. Traversal, null bytes, reserved
+/// names, and UNC-style inputs are rejected with HTTP 400. Bonus: the source's own StorageKey
+/// is treated as a trusted internal value (it was sanitized at upload time), but we still
+/// route it through <see cref="StoragePath.Parse"/> as defence-in-depth in case a corrupt row
+/// somehow contains a value that StoragePath would now reject.</para>
+/// </summary>
+public static class CopyFileEndpoints
+{
+    private const string RouteName = "CopyFile";
+    private const string GetFileRouteName = "GetFile";
+    private const int CrossEncryptionConflictStatus = StatusCodes.Status409Conflict;
+
+    public static IEndpointRouteBuilder MapCopyFileEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/drives/{driveId:guid}/files/{fileId:guid}/copy", CopyFileAsync)
+            .RequireAuthorization(AuthPolicies.FilesWrite)
+            .WithName(RouteName)
+            .WithTags("Files")
+            .WithSummary("Copy a file to a new path within the same drive or to a different drive.")
+            .WithDescription(
+                "Creates a fresh FileItem (new Guid) and FileVersion (v1) at the requested " +
+                "TargetPath, copying the source blob via the per-drive storage provider. The " +
+                "source file is unchanged. Quota is enforced via Commit-as-reservation: the " +
+                "atomic Commit happens before the storage write so an over-quota copy never " +
+                "touches the backend, and a failed storage write is compensated by Release. " +
+                "Cross-drive copies are supported via TargetDriveId; if omitted, the route's " +
+                "drive is reused. Returns 201 with the new file body, 400 on path-traversal / " +
+                "reserved name, 404 when source is missing or in another drive, 409 on target " +
+                "collision, 507 on quota exhaustion.");
+
+        return app;
+    }
+
+    private static async Task<IResult> CopyFileAsync(
+        Guid driveId,
+        Guid fileId,
+        [FromBody] CopyFileRequest request,
+        [FromServices] IFileRepository fileRepository,
+        [FromServices] IDriveRepository driveRepository,
+        [FromServices] IFileVersionRepository versionRepository,
+        [FromServices] IStorageProviderRegistry registry,
+        [FromServices] IQuotaService quotaService,
+        [FromServices] IPublishEndpoint publishEndpoint,
+        [FromServices] IStrgDbContext db,
+        [FromServices] ITenantContext tenantContext,
+        [FromServices] ILogger<CopyFileLog> logger,
+        ClaimsPrincipal user,
+        CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return Results.BadRequest(new { error = "Request body required." });
+        }
+
+        // 1) Path safety. StoragePath.Parse rejects traversal, null bytes, reserved names,
+        // absolute/UNC inputs, empty/whitespace. A 400 here is a request-shape failure — same
+        // surface the upload path returns on the same input.
+        StoragePath targetPath;
+        try
+        {
+            targetPath = StoragePath.Parse(request.TargetPath);
+        }
+        catch (StoragePathException ex)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: ex.Message);
+        }
+
+        // 2) Source resolution. Cross-drive id mismatch is collapsed to 404 — same enumeration-
+        // oracle stance as DeleteFileHandler. The global tenant + soft-delete filters on
+        // StrgDbContext.Files apply, so a cross-tenant probe returns null without leaking.
+        var source = await fileRepository.GetByIdAsync(fileId, cancellationToken).ConfigureAwait(false);
+        if (source is null || source.DriveId != driveId)
+        {
+            return Results.NotFound();
+        }
+
+        if (source.IsDirectory)
+        {
+            // The endpoint contract is single-file copy; recursive directory copy needs its own
+            // endpoint with explicit semantics around per-descendant quota commits and per-blob
+            // failure isolation. Surfacing 400 here is the right hint to the client — silently
+            // succeeding with no work would be worse, and partial-success on a half-recursed
+            // tree would be much worse.
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                detail: "Directory copy is not supported by this endpoint.");
+        }
+
+        var targetDriveId = request.TargetDriveId ?? driveId;
+        var userId = user.GetUserId();
+
+        // 3) Target drive lookup. IDriveRepository.GetByIdAsync honours the tenant filter, so a
+        // caller passing a TargetDriveId from another tenant returns null. Same-tenant + missing
+        // drive → 404, matching the source-drive 404 shape (no oracle).
+        var targetDrive = await driveRepository.GetByIdAsync(targetDriveId, cancellationToken).ConfigureAwait(false);
+        if (targetDrive is null)
+        {
+            return Results.NotFound();
+        }
+
+        // 4) Cross-encryption guard. v0.1 stores ciphertext in the underlying provider when
+        // EncryptionEnabled is set; the per-drive envelope/key context is part of the read path.
+        // Raw provider.CopyAsync() copies BYTES — copying a ciphertext blob to a plaintext drive
+        // (or vice-versa) leaves a payload that the receiving drive's read path cannot interpret.
+        // Surfacing 409 is the right early-rejection: the operation is semantically valid on
+        // matching-posture drives only. Same-drive copies trivially satisfy this.
+        if (driveId != targetDriveId)
+        {
+            var sourceDrive = await driveRepository.GetByIdAsync(driveId, cancellationToken).ConfigureAwait(false);
+            if (sourceDrive is null)
+            {
+                return Results.NotFound();
+            }
+            if (sourceDrive.EncryptionEnabled != targetDrive.EncryptionEnabled)
+            {
+                return Results.Problem(
+                    statusCode: CrossEncryptionConflictStatus,
+                    detail: "Cross-drive copy between drives with mismatched encryption posture is not supported.");
+            }
+        }
+
+        // 5) Collision check. The unique-key invariant on (DriveId, Path, IsDeleted=false) is
+        // enforced by the storage provider AND by the DB; this pre-check turns a race-loser
+        // 500 into the AC's 409 surface.
+        var collision = await db.Files
+            .AnyAsync(
+                f => f.DriveId == targetDriveId && f.Path == targetPath.Value,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (collision)
+        {
+            return Results.Conflict(new { error = "Target path already exists." });
+        }
+
+        // 6) Pre-flight quota check (advisory per STRG-032). The authoritative gate is CommitAsync
+        // below; this Check exists so the AC's "quota checked before copy" pin has a structurally
+        // distinct early path, and so the over-quota integration test does not need to race past
+        // a CommitAsync atomic-update to assert the 507 surface.
+        try
+        {
+            var checkResult = await quotaService.CheckAsync(userId, source.Size, cancellationToken).ConfigureAwait(false);
+            if (!checkResult.IsAllowed)
+            {
+                return Results.Problem(
+                    statusCode: StatusCodes.Status507InsufficientStorage,
+                    detail: "Storage quota exceeded.");
+            }
+        }
+        catch (QuotaExceededException)
+        {
+            // Missing-user collapse per IQuotaService class doc — safe to surface as 507 since
+            // the client already has files.write scope on a tenant-tied JWT, so this can only
+            // mean the user row was hard-deleted out from under them. Same wire shape as a real
+            // shortfall is the enumeration-oracle-safe choice.
+            return Results.Problem(
+                statusCode: StatusCodes.Status507InsufficientStorage,
+                detail: "Storage quota exceeded.");
+        }
+
+        // 7) Resolve provider(s) and confirm source has a storage key. A FileItem with
+        // StorageKey == null indicates a directory or an in-flight upload that hasn't finalised;
+        // we already filtered IsDirectory above, so a null here is a corrupt-row condition the
+        // 500 surface is appropriate for.
+        if (string.IsNullOrEmpty(source.StorageKey))
+        {
+            logger.LogError(
+                "File {FileId} has no StorageKey set; cannot copy.",
+                source.Id);
+            return Results.Problem(
+                statusCode: StatusCodes.Status500InternalServerError,
+                detail: "Source file is missing its storage key.");
+        }
+
+        // Same-drive copies use a single provider and the provider's native CopyAsync (avoids the
+        // read-write round trip). Cross-drive copies resolve BOTH providers and stream
+        // source.ReadAsync → target.WriteAsync; the issue's pseudocode showed only the target
+        // provider, which silently fails on a real cross-drive setup because the target's
+        // provider has no visibility into the source's storage backend (different rootPath, S3
+        // bucket, etc.).
+        var targetProviderConfig = DictionaryStorageProviderConfig.FromJson(targetDrive.ProviderConfig);
+        var targetProvider = registry.Resolve(targetDrive.ProviderType, targetProviderConfig);
+
+        IStorageProvider? sourceProvider = null;
+        if (driveId != targetDriveId)
+        {
+            // Cross-drive: re-fetch source drive (we already touched it for the encryption guard,
+            // but that result wasn't kept in scope). The tenant filter still applies — null
+            // collapses to 404, same as the source-FileItem branch above.
+            var sourceDriveForCopy = await driveRepository.GetByIdAsync(driveId, cancellationToken).ConfigureAwait(false);
+            if (sourceDriveForCopy is null)
+            {
+                return Results.NotFound();
+            }
+            var sourceProviderConfig = DictionaryStorageProviderConfig.FromJson(sourceDriveForCopy.ProviderConfig);
+            sourceProvider = registry.Resolve(sourceDriveForCopy.ProviderType, sourceProviderConfig);
+        }
+
+        // 8) Atomic-gate commit. Throws QuotaExceededException on shortfall — that's the 507
+        // surface. Note we do NOT release here on Commit failure: the commit was rejected, no
+        // bytes were charged, no compensation needed.
+        try
+        {
+            await quotaService.CommitAsync(userId, source.Size, cancellationToken).ConfigureAwait(false);
+        }
+        catch (QuotaExceededException)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status507InsufficientStorage,
+                detail: "Storage quota exceeded.");
+        }
+
+        // 9) Storage copy. From here on, any failure must release the quota or we leak budget.
+        // Same-drive: native CopyAsync. Cross-drive: read from source, stream-write to target —
+        // the streamed pattern keeps memory bounded for large files (no MemoryStream buffering).
+        var targetStorageKey = targetPath.Value;
+        try
+        {
+            if (sourceProvider is null)
+            {
+                await targetProvider.CopyAsync(source.StorageKey, targetStorageKey, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await using var sourceStream = await sourceProvider
+                    .ReadAsync(source.StorageKey, 0, cancellationToken)
+                    .ConfigureAwait(false);
+                await targetProvider.WriteAsync(targetStorageKey, sourceStream, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (FileNotFoundException ex)
+        {
+            // Source key disappeared between the FileItem lookup and the storage read — likely a
+            // concurrent delete or a corrupt FileItem.StorageKey. Release quota and surface 404.
+            await CompensateReleaseAsync(quotaService, userId, source.Size, logger).ConfigureAwait(false);
+            logger.LogWarning(ex,
+                "Source blob missing for file {FileId} (StorageKey={StorageKey})",
+                source.Id, source.StorageKey);
+            return Results.NotFound();
+        }
+        catch (IOException ex)
+        {
+            // Destination collision (LocalFileSystemProvider's File.Copy with overwrite:false,
+            // InMemoryStorageProvider's TryAdd-fails). The AnyAsync pre-check should have caught
+            // this, but a race between the collision-check query and the storage write IS
+            // theoretically possible under concurrent copies — surface 409 with quota release.
+            await CompensateReleaseAsync(quotaService, userId, source.Size, logger).ConfigureAwait(false);
+            logger.LogInformation(ex,
+                "Storage collision on copy to {TargetDriveId}/{TargetPath} (race past pre-check)",
+                targetDriveId, targetStorageKey);
+            return Results.Conflict(new { error = "Target path already exists." });
+        }
+        catch (Exception ex)
+        {
+            // Catch-all: storage backend errors (S3 5xx, disk-full, permission denied) collapse
+            // to 500 with quota release.
+            await CompensateReleaseAsync(quotaService, userId, source.Size, logger).ConfigureAwait(false);
+            logger.LogError(ex,
+                "CopyAsync failed for file {FileId} → {TargetDriveId}/{TargetPath}",
+                source.Id, targetDriveId, targetStorageKey);
+            return Results.Problem(
+                statusCode: StatusCodes.Status500InternalServerError,
+                detail: "Storage copy failed.");
+        }
+
+        // 10) Stage the new FileItem + FileVersion + outbox event. Entity.Id default = Guid.NewGuid()
+        // so the new file's id is distinct from the source by construction (issue's CR checklist
+        // explicitly pins this).
+        var newFile = new FileItem
+        {
+            // TenantId from context, NEVER from request body or source.TenantId. The tenant
+            // filter on Files invariably matches against ITenantContext.TenantId, so reading
+            // it from the same authority is the source of truth.
+            TenantId = tenantContext.TenantId,
+            DriveId = targetDriveId,
+            Name = ExtractFileName(targetPath.Value),
+            Path = targetPath.Value,
+            Size = source.Size,
+            ContentHash = source.ContentHash,
+            MimeType = source.MimeType,
+            IsDirectory = false,
+            StorageKey = targetStorageKey,
+            CreatedBy = userId,
+            VersionCount = 1,
+        };
+
+        var version = new FileVersion
+        {
+            FileId = newFile.Id,
+            VersionNumber = 1,
+            Size = source.Size,
+            BlobSizeBytes = source.Size,
+            ContentHash = source.ContentHash ?? string.Empty,
+            StorageKey = targetStorageKey,
+            CreatedBy = userId,
+        };
+
+        await fileRepository.AddAsync(newFile, cancellationToken).ConfigureAwait(false);
+        await versionRepository.AddAsync(version, cancellationToken).ConfigureAwait(false);
+
+        // 11) Publish via outbox interceptor BEFORE SaveChangesAsync — the interceptor stages an
+        // outbox row on the change tracker, the single SaveChangesAsync below commits the file,
+        // version, and outbox row in one transaction. See DeleteFileHandler for the same
+        // ordering rationale.
+        await publishEndpoint.Publish(
+            new FileUploadedEvent(
+                tenantContext.TenantId,
+                newFile.Id,
+                targetDriveId,
+                userId,
+                source.Size,
+                source.MimeType),
+            cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // SaveChanges failed AFTER provider.CopyAsync succeeded → orphan blob on target +
+            // wasted quota. Best-effort: release quota AND delete the orphan blob. Failing
+            // either compensation cleanly logs but doesn't supersede the original failure.
+            await CompensateReleaseAsync(quotaService, userId, source.Size, logger).ConfigureAwait(false);
+            try
+            {
+                await targetProvider.DeleteAsync(targetStorageKey, CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception cleanupEx)
+            {
+                logger.LogWarning(cleanupEx,
+                    "Best-effort orphan-blob delete failed for {TargetPath}",
+                    targetStorageKey);
+            }
+            logger.LogError(ex,
+                "SaveChangesAsync failed after storage copy for file {NewFileId}",
+                newFile.Id);
+            return Results.Problem(
+                statusCode: StatusCodes.Status500InternalServerError,
+                detail: "Failed to persist copied file metadata.");
+        }
+
+        // 12) 201 Created with the new file's wire DTO. The Location header points at a future
+        // GET-by-id route; until that endpoint exists, the body is the authoritative payload.
+        var dto = FileItemDto.From(newFile);
+        return Results.Created(
+            $"/api/v1/drives/{targetDriveId}/files/{newFile.Id}",
+            dto);
+    }
+
+    private static async Task CompensateReleaseAsync(
+        IQuotaService quotaService,
+        Guid userId,
+        long bytes,
+        ILogger logger)
+    {
+        try
+        {
+            await quotaService.ReleaseAsync(userId, bytes, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // ReleaseAsync is documented to no-op on missing user; reaching here means a real
+            // DB error. Log but don't supersede the caller-facing failure — the original
+            // exception is the actionable one.
+            logger.LogWarning(ex,
+                "Quota compensation release failed for user {UserId} ({Bytes} bytes)",
+                userId, bytes);
+        }
+    }
+
+    private static string ExtractFileName(string storagePath)
+    {
+        // StoragePath.Normalize trims leading/trailing slashes and replaces backslashes; the last
+        // segment after '/' is the filename. A bare filename (no slash) is its own filename.
+        var lastSlash = storagePath.LastIndexOf('/');
+        return lastSlash < 0 ? storagePath : storagePath[(lastSlash + 1)..];
+    }
+
+    /// <summary>
+    /// Logger category marker — gives the static endpoint method a stable
+    /// <c>ILogger&lt;CopyFileLog&gt;</c> binding without exposing the static class as a generic
+    /// type parameter.
+    /// </summary>
+    public sealed class CopyFileLog;
+}

--- a/src/Strg.Api/Endpoints/CopyFileRequest.cs
+++ b/src/Strg.Api/Endpoints/CopyFileRequest.cs
@@ -1,0 +1,16 @@
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// Request body for the STRG-041 copy endpoint.
+///
+/// <para><b>TargetPath</b> is the destination path within <see cref="TargetDriveId"/> (or the route
+/// drive when omitted). User-supplied input — gated by <c>StoragePath.Parse</c> in the handler so
+/// traversal, null bytes, reserved names, and absolute/UNC inputs are rejected before they reach
+/// the storage provider.</para>
+///
+/// <para><b>TargetDriveId</b> is optional. <c>null</c> means "copy within the route drive"; a
+/// non-null value enables cross-drive copy. The destination drive must exist and belong to the
+/// caller's tenant — the global query filter on <c>StrgDbContext.Drives</c> enforces that
+/// transitively when <c>IDriveRepository.GetByIdAsync</c> is called against the resolved id.</para>
+/// </summary>
+public sealed record CopyFileRequest(string TargetPath, Guid? TargetDriveId);

--- a/src/Strg.Api/Endpoints/FileListEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileListEndpoints.cs
@@ -73,16 +73,7 @@ public static class FileListEndpoints
         return Results.Ok(new FileListResponse(items, result.Page, result.PageSize, result.TotalCount));
     }
 
-    private static FileItemDto ToDto(FileItem f) => new(
-        f.Id,
-        f.Name,
-        f.Path,
-        f.Size,
-        f.MimeType,
-        f.IsDirectory,
-        f.ContentHash,
-        f.CreatedAt,
-        f.UpdatedAt);
+    private static FileItemDto ToDto(FileItem f) => FileItemDto.From(f);
 }
 
 public record FileItemDto(
@@ -94,7 +85,27 @@ public record FileItemDto(
     bool IsDirectory,
     string? ContentHash,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt)
+{
+    /// <summary>
+    /// Projects a <see cref="FileItem"/> onto the wire DTO. The same projection is used by every
+    /// REST endpoint that returns a single FileItem (list, copy, future move/rename) so the wire
+    /// shape stays in lockstep — no chance of one endpoint accidentally exposing
+    /// <see cref="FileItem.StorageKey"/>, <see cref="TenantedEntity.TenantId"/>, or
+    /// <see cref="FileItem.ParentId"/> while another correctly omits them. The omissions are the
+    /// security contract documented at <see cref="FileListEndpoints"/>.
+    /// </summary>
+    public static FileItemDto From(FileItem f) => new(
+        f.Id,
+        f.Name,
+        f.Path,
+        f.Size,
+        f.MimeType,
+        f.IsDirectory,
+        f.ContentHash,
+        f.CreatedAt,
+        f.UpdatedAt);
+}
 
 public record FileListResponse(
     IReadOnlyList<FileItemDto> Items,

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -409,6 +409,7 @@ app.MapDriveEndpoints();
 app.MapFileDownloadEndpoints();
 app.MapFileListEndpoints();
 app.MapFileDeleteEndpoints();
+app.MapCopyFileEndpoints();
 app.MapUserRegistrationEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)

--- a/tests/Strg.Integration.Tests/Files/CopyFileEndpointFixture.cs
+++ b/tests/Strg.Integration.Tests/Files/CopyFileEndpointFixture.cs
@@ -1,0 +1,176 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Integration.Tests.Upload;
+
+namespace Strg.Integration.Tests.Files;
+
+/// <summary>
+/// HTTP-level fixture for the STRG-041 file-copy endpoint. Inherits
+/// <see cref="StrgTusUploadFixture"/>'s PostgreSQL + RabbitMQ container shape (one container
+/// per test class) and its seeded encrypted local-FS drive.
+///
+/// <para>We need real bytes on disk to exercise the storage <see cref="Strg.Core.Storage.IStorageProvider.CopyAsync"/>
+/// path: a copy of "no source content" returns success vacuously and would mask the
+/// "different Id, same content" assertion in TC-001. <see cref="SeedFileWithContentAsync"/>
+/// writes the bytes through the registry-resolved provider so the test exercises the same
+/// drive/provider plumbing the production endpoint hits.</para>
+///
+/// <para>Paths are seeded in storage-normalized form (no leading or trailing slash),
+/// matching <c>StoragePath.Normalize</c>'s output.</para>
+/// </summary>
+public sealed class CopyFileEndpointFixture : StrgTusUploadFixture
+{
+    /// <summary>
+    /// Seeds a single <see cref="FileItem"/> on the fixture's drive AND writes the
+    /// corresponding bytes through the storage provider. The fixture's drive uses the
+    /// LocalFileSystemProvider rooted at <see cref="StrgTusUploadFixture.TempStorageRoot"/>;
+    /// a successful seed leaves a real file on disk that <c>provider.CopyAsync</c> in the
+    /// endpoint can copy from.
+    ///
+    /// <para>Note the fixture-inherited drive has <see cref="Drive.EncryptionEnabled"/> = true
+    /// in the parent, but encryption is applied at the writer layer
+    /// (<c>AesGcmFileWriter</c>) — the raw provider stores ciphertext blobs in production.
+    /// For copy tests we want byte-for-byte identity in storage, so we write the raw bytes
+    /// directly via <c>provider.WriteAsync</c> (bypassing the encrypting writer). The copy
+    /// endpoint also bypasses the encrypting layer (it copies opaque blobs), so this matches
+    /// the production behaviour of "copy whatever bytes are at the source key".</para>
+    /// </summary>
+    public async Task<Guid> SeedFileWithContentAsync(
+        string path,
+        byte[] content,
+        string mimeType = "application/octet-stream",
+        Guid? driveId = null,
+        CancellationToken cancellationToken = default)
+    {
+        var name = path.Contains('/') ? path[(path.LastIndexOf('/') + 1)..] : path;
+        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(content));
+
+        var resolvedDriveId = driveId ?? DriveId;
+
+        await using var ctx = NewDbContext();
+        var file = new FileItem
+        {
+            TenantId = TenantId,
+            DriveId = resolvedDriveId,
+            Name = name,
+            Path = path,
+            IsDirectory = false,
+            Size = content.Length,
+            ContentHash = contentHash,
+            MimeType = mimeType,
+            StorageKey = path,
+            CreatedBy = UserId,
+            VersionCount = 1,
+        };
+        ctx.Files.Add(file);
+
+        var version = new FileVersion
+        {
+            FileId = file.Id,
+            VersionNumber = 1,
+            Size = content.Length,
+            BlobSizeBytes = content.Length,
+            ContentHash = contentHash,
+            StorageKey = path,
+            CreatedBy = UserId,
+        };
+        ctx.FileVersions.Add(version);
+
+        await ctx.SaveChangesAsync(cancellationToken);
+
+        // Write actual bytes to the storage backend so the endpoint's provider.CopyAsync has
+        // real content to copy. The fixture's drive is "local" → LocalFileSystemProvider rooted
+        // at TempStorageRoot.
+        var rootPath = ReadDriveRootPath(resolvedDriveId);
+        var fullPath = System.IO.Path.Combine(rootPath, path.Replace('/', System.IO.Path.DirectorySeparatorChar));
+        var parentDir = System.IO.Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(parentDir))
+        {
+            Directory.CreateDirectory(parentDir);
+        }
+        await File.WriteAllBytesAsync(fullPath, content, cancellationToken);
+
+        return file.Id;
+    }
+
+    /// <summary>
+    /// Seeds a second <see cref="Drive"/> on the same tenant with its own temp root. Used by
+    /// the cross-drive copy tests so a different <c>TargetDriveId</c> resolves to a separate
+    /// filesystem root, which proves the registry resolution path picks up the target's own
+    /// provider config and not the source's.
+    /// </summary>
+    public async Task<(Guid DriveId, string RootPath)> SeedSecondDriveAsync(
+        bool encryptionEnabled,
+        CancellationToken cancellationToken = default)
+    {
+        var rootPath = Directory.CreateTempSubdirectory($"strg-copy-it-target-{Guid.NewGuid():N}").FullName;
+
+        await using var ctx = NewDbContext();
+        var drive = new Drive
+        {
+            TenantId = TenantId,
+            Name = $"copy-target-{Guid.NewGuid():N}".ToLowerInvariant(),
+            ProviderType = "local",
+            ProviderConfig = JsonSerializer.Serialize(new { rootPath }),
+            EncryptionEnabled = encryptionEnabled,
+        };
+        ctx.Drives.Add(drive);
+        await ctx.SaveChangesAsync(cancellationToken);
+        return (drive.Id, rootPath);
+    }
+
+    /// <summary>
+    /// Force-sets the user's <c>UsedBytes</c> to <paramref name="usedBytes"/>. Symmetric with
+    /// <see cref="StrgTusUploadFixture.SetUserQuotaAsync"/> but more direct for the
+    /// "next copy will exceed" path: pinning UsedBytes is easier than computing a quota that
+    /// matches the size we're about to push.
+    /// </summary>
+    public async Task SetUserUsedBytesAsync(long usedBytes, CancellationToken cancellationToken = default)
+    {
+        await using var ctx = NewDbContext();
+        var u = await ctx.Users.IgnoreQueryFilters().SingleAsync(x => x.Id == UserId, cancellationToken);
+        u.UsedBytes = usedBytes;
+        await ctx.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads the seeded drive's root path from <c>Drive.ProviderConfig</c>. The fixture's
+    /// inherited drive uses <see cref="StrgTusUploadFixture.TempStorageRoot"/>; second-drive
+    /// seeders track theirs separately.
+    /// </summary>
+    public string ReadDriveRootPath(Guid driveId)
+    {
+        if (driveId == DriveId)
+        {
+            return TempStorageRoot;
+        }
+        using var ctx = NewDbContext();
+        var drive = ctx.Drives.Single(d => d.Id == driveId);
+        var doc = JsonDocument.Parse(drive.ProviderConfig);
+        return doc.RootElement.GetProperty("rootPath").GetString()!;
+    }
+
+    /// <summary>
+    /// POSTs the password grant with a caller-supplied scope list. Mirrors
+    /// <c>FileDeleteFixture.AuthenticateWithScopesAsync</c> — needed to exercise the 403 path
+    /// for callers without <c>files.write</c>.
+    /// </summary>
+    public async Task<string> AuthenticateWithScopesAsync(string scopes)
+    {
+        using var client = CreateClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "password",
+            ["username"] = UserEmail,
+            ["password"] = TestPassword,
+            ["client_id"] = "strg-default",
+            ["scope"] = scopes,
+        });
+        using var response = await client.PostAsync("/connect/token", form);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return json.GetProperty("access_token").GetString()!;
+    }
+}

--- a/tests/Strg.Integration.Tests/Files/CopyFileEndpointTests.cs
+++ b/tests/Strg.Integration.Tests/Files/CopyFileEndpointTests.cs
@@ -1,0 +1,315 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Strg.Api.Endpoints;
+using Strg.Core.Domain;
+using Xunit;
+
+namespace Strg.Integration.Tests.Files;
+
+/// <summary>
+/// STRG-041 — REST file-copy endpoint integration tests. Class-scoped fixture
+/// (<see cref="CopyFileEndpointFixture"/>) gives one PostgreSQL + RabbitMQ container shared
+/// across all test methods. Each test scopes its seeded files under a unique top-level
+/// folder so state from earlier tests in the same class can't bleed into later assertions.
+/// </summary>
+public sealed class CopyFileEndpointTests(CopyFileEndpointFixture fx) : IClassFixture<CopyFileEndpointFixture>
+{
+    [Fact]
+    public async Task TC001_Copy_CreatesNewFile_WithDifferentId_AndSameContent()
+    {
+        // Per AC: "POST /copy → 201 Created with new FileItem (different Id from source)" and
+        // "Copy → new file has different Id, same content". We assert (a) HTTP 201, (b) the new
+        // FileItem.Id != source.Id (issue's CR checklist), (c) the storage blob is byte-for-byte
+        // identical at the new path, (d) a FileVersion v1 row exists for the new file.
+        var folder = $"tc001-{Guid.NewGuid():N}";
+        var content = Encoding.UTF8.GetBytes("hello copy world " + Guid.NewGuid().ToString("N"));
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/source.txt", content);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/copy.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "201 is the AC's stated success surface for the copy endpoint");
+
+        var dto = await response.Content.ReadFromJsonAsync<FileItemDto>();
+        dto.Should().NotBeNull();
+        dto!.Id.Should().NotBe(sourceId,
+            "the new FileItem.Id is a fresh Guid.NewGuid() per the issue's code-review checklist");
+        dto.Path.Should().Be($"{folder}/copy.txt");
+        dto.Size.Should().Be(content.Length);
+        dto.ContentHash.Should().Be(
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(content)));
+
+        // Verify the storage blob landed at the target path with identical content. The fixture's
+        // drive uses LocalFileSystemProvider rooted at TempStorageRoot.
+        var rootPath = fx.ReadDriveRootPath(fx.DriveId);
+        var copiedFile = System.IO.Path.Combine(rootPath, folder, "copy.txt");
+        File.Exists(copiedFile).Should().BeTrue("storage provider must have created the new blob");
+        var copiedBytes = await File.ReadAllBytesAsync(copiedFile);
+        copiedBytes.Should().BeEquivalentTo(content, "copy must be byte-for-byte identical");
+
+        // Verify FileVersion v1 row exists for the new file (issue's CR checklist).
+        await using var ctx = fx.NewDbContext();
+        var version = await ctx.FileVersions
+            .FirstOrDefaultAsync(v => v.FileId == dto.Id);
+        version.Should().NotBeNull(
+            "the copy endpoint must create a FileVersion for the new file");
+        version!.VersionNumber.Should().Be(1,
+            "FileVersion.VersionNumber = 1 per the issue's code-review checklist");
+        version.Size.Should().Be(content.Length);
+    }
+
+    [Fact]
+    public async Task TC002_Copy_ToExistingPath_Returns409Conflict()
+    {
+        // AC: "Copy to existing path → 409 Conflict". We seed both source and target paths up
+        // front, then attempt to copy onto the occupied target.
+        var folder = $"tc002-{Guid.NewGuid():N}";
+        var content = Encoding.UTF8.GetBytes("source content");
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/source.txt", content);
+        await fx.SeedFileWithContentAsync($"{folder}/already-here.txt", Encoding.UTF8.GetBytes("blocker"));
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/already-here.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+        // The target row must not have been replaced — assert the original occupant survives by
+        // hash (the same path in the DB before and after the rejected copy).
+        await using var ctx = fx.NewDbContext();
+        var occupants = await ctx.Files
+            .Where(f => f.DriveId == fx.DriveId && f.Path == $"{folder}/already-here.txt")
+            .ToListAsync();
+        occupants.Should().HaveCount(1, "the existing occupant must still be the only row at that path");
+        occupants[0].ContentHash.Should().Be(
+            Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes("blocker"))),
+            "the rejected copy must not have replaced the existing occupant's content");
+    }
+
+    [Fact]
+    public async Task TC003_Copy_ExceedsQuota_Returns507InsufficientStorage()
+    {
+        // AC: "Copy exceeds quota → 507 Insufficient Storage". We seed a file the user already
+        // owns, then push UsedBytes up so the next copy of source.Size bytes exceeds the quota.
+        var folder = $"tc003-{Guid.NewGuid():N}";
+        var content = new byte[1024]; // 1 KiB
+        new Random(42).NextBytes(content);
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/source.bin", content);
+
+        // Pin UsedBytes to QuotaBytes so the very next byte exceeds. CheckAsync's Available
+        // computation is QuotaBytes - UsedBytes; with these equal, requiredBytes > 0 fails.
+        await fx.SetUserUsedBytesAsync(fx.QuotaBytes);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/copy.bin", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InsufficientStorage,
+            "507 is the AC's stated quota-shortfall surface");
+
+        // The endpoint must not have created a target FileItem when quota was rejected.
+        await using var ctx = fx.NewDbContext();
+        var targetExists = await ctx.Files
+            .AnyAsync(f => f.DriveId == fx.DriveId && f.Path == $"{folder}/copy.bin");
+        targetExists.Should().BeFalse(
+            "no FileItem may exist at the target path when quota check rejected the copy");
+
+        // Restore UsedBytes for downstream tests in the same class fixture.
+        await fx.SetUserUsedBytesAsync(0);
+    }
+
+    [Fact]
+    public async Task TC004_Copy_LeavesSourceFileUnchanged()
+    {
+        // AC: "Original file unchanged" + "Copy → new file has different Id, same content".
+        // We snapshot the source row and storage blob before the copy, perform a successful
+        // copy, then re-snapshot and assert byte-for-byte identity on both.
+        var folder = $"tc004-{Guid.NewGuid():N}";
+        var content = Encoding.UTF8.GetBytes("immutable source " + Guid.NewGuid().ToString("N"));
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/source.txt", content);
+
+        // Snapshot source state before copy.
+        FileItem sourceBefore;
+        await using (var ctx = fx.NewDbContext())
+        {
+            sourceBefore = await ctx.Files.SingleAsync(f => f.Id == sourceId);
+        }
+        var rootPath = fx.ReadDriveRootPath(fx.DriveId);
+        var sourceBlobPath = System.IO.Path.Combine(rootPath, folder, "source.txt");
+        var blobBefore = await File.ReadAllBytesAsync(sourceBlobPath);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/copy.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Re-snapshot source.
+        FileItem sourceAfter;
+        await using (var ctx = fx.NewDbContext())
+        {
+            sourceAfter = await ctx.Files.SingleAsync(f => f.Id == sourceId);
+        }
+        var blobAfter = await File.ReadAllBytesAsync(sourceBlobPath);
+
+        sourceAfter.Path.Should().Be(sourceBefore.Path,
+            "the source FileItem.Path must not have shifted");
+        sourceAfter.Size.Should().Be(sourceBefore.Size);
+        sourceAfter.ContentHash.Should().Be(sourceBefore.ContentHash);
+        sourceAfter.StorageKey.Should().Be(sourceBefore.StorageKey);
+        sourceAfter.IsDeleted.Should().BeFalse("the source must not be soft-deleted by the copy");
+        blobAfter.Should().BeEquivalentTo(blobBefore,
+            "the source blob's bytes must be byte-for-byte unchanged");
+    }
+
+    [Fact]
+    public async Task Copy_PathTraversal_Returns400()
+    {
+        var folder = $"trav-{Guid.NewGuid():N}";
+        var content = Encoding.UTF8.GetBytes("source");
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/source.txt", content);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        // StoragePath.Parse rejects '..' segments and absolute paths — surface is 400.
+        var request = new CopyFileRequest("../../etc/passwd", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Copy_Unauthenticated_Returns401()
+    {
+        var folder = $"unauth-{Guid.NewGuid():N}";
+        var sourceId = await fx.SeedFileWithContentAsync(
+            $"{folder}/src.txt", Encoding.UTF8.GetBytes("x"));
+
+        using var client = fx.CreateClient();
+        var request = new CopyFileRequest($"{folder}/dst.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Copy_WithoutFilesWriteScope_Returns403()
+    {
+        // RequireAuthorization(AuthPolicies.FilesWrite) gates the route — a token with files.read
+        // but no files.write is rejected with 403 before the handler runs.
+        var folder = $"scope-{Guid.NewGuid():N}";
+        var sourceId = await fx.SeedFileWithContentAsync(
+            $"{folder}/src.txt", Encoding.UTF8.GetBytes("x"));
+
+        var token = await fx.AuthenticateWithScopesAsync("files.read files.share");
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/dst.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Copy_FromWrongDrive_Returns404()
+    {
+        // Cross-drive id mismatch is collapsed to 404 (NOT 403) so the wire shape cannot
+        // enumerate which drive a file belongs to. Same enumeration-oracle stance as
+        // FileDeleteHandler.
+        var folder = $"wrongdrive-{Guid.NewGuid():N}";
+        var sourceId = await fx.SeedFileWithContentAsync(
+            $"{folder}/src.txt", Encoding.UTF8.GetBytes("x"));
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/dst.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{Guid.NewGuid()}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Copy_UnknownFile_Returns404()
+    {
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest("dst.txt", null);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{Guid.NewGuid()}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CrossDriveCopy_SameTenant_SameEncryptionPosture_Succeeds()
+    {
+        // The optional TargetDriveId routes the copy to a different drive on the same tenant.
+        // This pins (a) the registry resolves the TARGET drive's provider config (so the
+        // target's rootPath, not the source's, owns the new blob) and (b) the new FileItem
+        // carries the target's DriveId.
+        var folder = $"xdrive-{Guid.NewGuid():N}";
+        var content = Encoding.UTF8.GetBytes("cross drive payload " + Guid.NewGuid().ToString("N"));
+        var sourceId = await fx.SeedFileWithContentAsync($"{folder}/src.txt", content);
+
+        // Match the fixture's source-drive encryption posture (true) so the cross-encryption
+        // guard doesn't 409 us. This test is about ROUTING, not encryption-mismatch handling.
+        var (targetDriveId, targetRoot) = await fx.SeedSecondDriveAsync(encryptionEnabled: true);
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var request = new CopyFileRequest($"{folder}/dst.txt", targetDriveId);
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var dto = await response.Content.ReadFromJsonAsync<FileItemDto>();
+        dto.Should().NotBeNull();
+        dto!.Path.Should().Be($"{folder}/dst.txt");
+
+        await using var ctx = fx.NewDbContext();
+        var newRow = await ctx.Files.SingleAsync(f => f.Id == dto.Id);
+        newRow.DriveId.Should().Be(targetDriveId,
+            "the new FileItem must live on the TARGET drive, not the source drive");
+
+        // Verify the blob landed on the TARGET filesystem root, not the source's.
+        var targetBlob = System.IO.Path.Combine(targetRoot, folder, "dst.txt");
+        File.Exists(targetBlob).Should().BeTrue(
+            "the storage copy must hit the target drive's provider config (rootPath)");
+    }
+}


### PR DESCRIPTION
## Summary
- POST /api/v1/drives/{driveId}/files/{fileId}/copy
- Cross-drive support via optional targetDriveId
- Quota enforced via single-phase Commit-as-reservation; ReleaseAsync compensation on storage failure
- New FileItem (fresh Guid) + FileVersion (version 1)
- FileUploadedEvent published through MassTransit outbox interceptor (publish-before-Save)

## Test plan
- [x] TC-001 copy → new file with different Id, same content
- [x] TC-002 copy to occupied path → 409
- [x] TC-003 copy exceeding quota → 507
- [x] TC-004 source unchanged after copy
- [x] Path traversal → 400
- [x] Unauthenticated → 401
- [x] Without files.write scope → 403
- [x] Cross-drive (same encryption posture) → 201
- [x] Wrong drive id → 404
- [x] Unknown file → 404

## Notes
- Cross-drive copies stream source.ReadAsync → target.WriteAsync. The issue's pseudocode shows a single-provider CopyAsync, which only works for same-drive copies; the target's provider has no visibility into the source's storage backend.
- Cross-encryption-posture cross-drive copies surface 409 — copying ciphertext bytes raw to a plaintext drive (or vice-versa) leaves payload unreadable. Same-drive copies always pass this guard trivially.
- Outbox publish ordering follows DeleteFileHandler (publish before SaveChanges, MassTransit UseBusOutbox stages the publish on the change tracker). CLAUDE.md's "publish AFTER" pre-dates the interceptor wiring per project memory.

Closes #13