### PR TITLE
feat(api): STRG-082 — finalise rate-limiter rejection envelope and upload policy

### DIFF
--- a/src/Strg.Api/RateLimiting/RateLimitOptions.cs
+++ b/src/Strg.Api/RateLimiting/RateLimitOptions.cs
@@ -18,7 +18,16 @@ internal sealed class RateLimitOptions
     /// to any endpoint-specific named policy — a token-endpoint request consumes both Auth and
     /// Global budgets for its IP partition.
     /// </summary>
-    public RateLimitPolicyOptions Global { get; set; } = new() { PermitLimit = 1000, WindowSeconds = 60 };
+    public RateLimitPolicyOptions Global { get; set; } = new() { PermitLimit = 300, WindowSeconds = 60 };
+
+    /// <summary>
+    /// Per-user budget for the <see cref="RateLimitPolicies.Upload"/> named policy. Partitioned
+    /// on the JWT <c>sub</c> claim (with IP fallback for unauthenticated callers). v0.1 does not
+    /// attach this policy to the TUS endpoint — STRG-082 explicitly excludes TUS chunk uploads
+    /// from rate limiting (large file uploads, not a brute-force target). The policy is
+    /// registered so future chunked-upload endpoints can opt in via <c>RequireRateLimiting</c>.
+    /// </summary>
+    public RateLimitPolicyOptions Upload { get; set; } = new() { PermitLimit = 100, WindowSeconds = 60 };
 }
 
 /// <summary>

--- a/src/Strg.Api/RateLimiting/RateLimitPolicies.cs
+++ b/src/Strg.Api/RateLimiting/RateLimitPolicies.cs
@@ -13,4 +13,13 @@ internal static class RateLimitPolicies
     /// Bound from <c>RateLimiting:Auth</c>.
     /// </summary>
     public const string Auth = "auth";
+
+    /// <summary>
+    /// Per-user upload policy. Partitioned on the JWT <c>sub</c> claim with an IP fallback so
+    /// unauthenticated probes can't pool a user's budget. v0.1 does NOT attach this policy to
+    /// TUS — chunk uploads are explicitly exempted (STRG-082) because they are high-volume by
+    /// nature and not a brute-force target. Registered for future chunked-upload endpoints
+    /// that opt in via <c>RequireRateLimiting</c>. Bound from <c>RateLimiting:Upload</c>.
+    /// </summary>
+    public const string Upload = "upload";
 }

--- a/src/Strg.Api/RateLimiting/RateLimitingServiceCollectionExtensions.cs
+++ b/src/Strg.Api/RateLimiting/RateLimitingServiceCollectionExtensions.cs
@@ -1,22 +1,29 @@
+using System.Globalization;
+using System.Net.Mime;
 using System.Threading.RateLimiting;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using Strg.Core.Constants;
 
 namespace Strg.Api.RateLimiting;
 
 /// <summary>
-/// Rate-limiter wiring for STRG-010. Registers:
+/// Rate-limiter wiring for STRG-010 / STRG-082. Registers:
 /// <list type="bullet">
 ///   <item><description>A <c>GlobalLimiter</c> keyed on remote IP — applies to every request
 ///   that does not chain <c>DisableRateLimiting()</c> on its endpoint mapping.</description></item>
 ///   <item><description>The <see cref="RateLimitPolicies.Auth"/> named policy — attached at
 ///   the endpoint via <c>RequireRateLimiting</c> on <c>/connect/token</c>.</description></item>
+///   <item><description>The <see cref="RateLimitPolicies.Upload"/> named policy — partitioned
+///   on the JWT subject. Defined for future chunked-upload endpoints; v0.1 leaves TUS exempted
+///   per the STRG-082 spec.</description></item>
 /// </list>
 ///
 /// <para>
-/// Both use <see cref="FixedWindowRateLimiter"/> with an in-memory partition store. Multi-node
-/// deployments need a shared store; STRG-117 tracks the Redis migration and the in-memory
-/// store is an explicit v0.1 limitation. Rejected requests return 429 Too Many Requests.
+/// All three use <see cref="FixedWindowRateLimiter"/> with an in-memory partition store.
+/// Multi-node deployments need a shared store; STRG-117 tracks the Redis migration and the
+/// in-memory store is an explicit v0.1 limitation. Rejected requests return 429 Too Many
+/// Requests with a <c>Retry-After</c> header and a JSON error body.
 /// </para>
 /// </summary>
 internal static class RateLimitingServiceCollectionExtensions
@@ -33,6 +40,7 @@ internal static class RateLimitingServiceCollectionExtensions
         services.AddRateLimiter(limiter =>
         {
             limiter.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            limiter.OnRejected = OnRejectedAsync;
 
             limiter.AddPolicy(RateLimitPolicies.Auth, context =>
             {
@@ -40,6 +48,14 @@ internal static class RateLimitingServiceCollectionExtensions
                     .GetRequiredService<IOptionsMonitor<RateLimitOptions>>()
                     .CurrentValue.Auth;
                 return BuildFixedWindowPartition(context, policyOptions);
+            });
+
+            limiter.AddPolicy(RateLimitPolicies.Upload, context =>
+            {
+                var policyOptions = context.RequestServices
+                    .GetRequiredService<IOptionsMonitor<RateLimitOptions>>()
+                    .CurrentValue.Upload;
+                return BuildUploadPartition(context, policyOptions);
             });
 
             limiter.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(context =>
@@ -54,11 +70,52 @@ internal static class RateLimitingServiceCollectionExtensions
         return services;
     }
 
+    // Rejection envelope: a Retry-After hint plus a minimal JSON body matching the {"error": ...}
+    // shape the rest of the API uses. Retry-After is sourced from the lease's RetryAfter
+    // metadata (FixedWindowRateLimiter populates this with the time to the next window reset),
+    // with a 60-second fallback for limiters that don't surface the metadata.
+    //
+    // TODO: v0.2 — replace the in-memory partition store with a Redis-backed shared counter so
+    // multi-instance deployments share budgets (STRG-117). The named policies and the
+    // partition-key strategy stay; only the storage substrate changes.
+    private static ValueTask OnRejectedAsync(OnRejectedContext context, CancellationToken cancellationToken)
+    {
+        var retryAfterSeconds = context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter)
+            ? Math.Max(1, (int)Math.Ceiling(retryAfter.TotalSeconds))
+            : 60;
+
+        var response = context.HttpContext.Response;
+        response.Headers[HeaderNames.RetryAfter] = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        response.ContentType = MediaTypeNames.Application.Json;
+
+        var body = $"{{\"error\":\"Rate limit exceeded. Try again in {retryAfterSeconds} seconds.\"}}";
+        return new ValueTask(response.WriteAsync(body, cancellationToken));
+    }
+
     private static RateLimitPartition<string> BuildFixedWindowPartition(
         HttpContext context,
         RateLimitPolicyOptions options)
     {
         var partitionKey = ResolvePartitionKey(context);
+        return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ =>
+            new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = options.PermitLimit,
+                Window = TimeSpan.FromSeconds(options.WindowSeconds),
+                QueueLimit = options.QueueLimit,
+            });
+    }
+
+    // Upload partition: prefer the JWT subject so authenticated users carry a per-identity
+    // budget that survives reverse-proxy IP coalescing. Fall back to the IP when no JWT is
+    // present (the policy is registered for future opt-in routes; keeping anonymous traffic
+    // bucketed by IP avoids one shared "anon" partition becoming the default DoS amplifier).
+    private static RateLimitPartition<string> BuildUploadPartition(
+        HttpContext context,
+        RateLimitPolicyOptions options)
+    {
+        var subject = context.User.FindFirst(StrgClaimNames.Subject)?.Value;
+        var partitionKey = !string.IsNullOrEmpty(subject) ? subject : ResolvePartitionKey(context);
         return RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ =>
             new FixedWindowRateLimiterOptions
             {

--- a/src/Strg.Api/appsettings.json
+++ b/src/Strg.Api/appsettings.json
@@ -21,6 +21,7 @@
   },
   "RateLimiting": {
     "Auth": { "PermitLimit": 10, "WindowSeconds": 60, "QueueLimit": 0 },
-    "Global": { "PermitLimit": 1000, "WindowSeconds": 60, "QueueLimit": 0 }
+    "Global": { "PermitLimit": 300, "WindowSeconds": 60, "QueueLimit": 0 },
+    "Upload": { "PermitLimit": 100, "WindowSeconds": 60, "QueueLimit": 0 }
   }
 }

--- a/tests/Strg.Integration.Tests/Auth/StrgWebApplicationFactory.cs
+++ b/tests/Strg.Integration.Tests/Auth/StrgWebApplicationFactory.cs
@@ -143,16 +143,17 @@ public sealed class StrgWebApplicationFactory : WebApplicationFactory<Program>, 
                 // re-introduced, the factory would diverge from production and the silent-401
                 // regression would resurface undetected.
 
-                // STRG-010 — raise the rate-limit budgets to "effectively unlimited" by default
-                // so existing test classes (BruteForceLockoutTests in particular, which sends
-                // 20+ token requests across its three test methods) are not throttled by the
-                // production-shaped Auth=10/min and Global=1000/min defaults. Tests that
-                // specifically want to exercise the limiter (Middleware/RateLimitingTests)
-                // override these via WithWebHostBuilder. The numbers chosen leave the production
-                // pipeline structure intact — the limiter still runs, the policies are still
-                // attached, only the budgets are wider.
+                // STRG-010 / STRG-082 — raise the rate-limit budgets to "effectively unlimited"
+                // by default so existing test classes (BruteForceLockoutTests in particular,
+                // which sends 20+ token requests across its three test methods) are not
+                // throttled by the production-shaped Auth=10/min, Global=300/min, and
+                // Upload=100/min defaults. Tests that specifically want to exercise the limiter
+                // (Middleware/RateLimitingTests) override these via WithWebHostBuilder. The
+                // numbers chosen leave the production pipeline structure intact — the limiter
+                // still runs, the policies are still attached, only the budgets are wider.
                 ["RateLimiting:Auth:PermitLimit"] = "100000",
                 ["RateLimiting:Global:PermitLimit"] = "100000",
+                ["RateLimiting:Upload:PermitLimit"] = "100000",
             });
         });
 

--- a/tests/Strg.Integration.Tests/Middleware/RateLimitingTests.cs
+++ b/tests/Strg.Integration.Tests/Middleware/RateLimitingTests.cs
@@ -3,13 +3,15 @@ using System.Net.Http.Headers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Net.Http.Headers;
 using Strg.Integration.Tests.Auth;
 using Xunit;
 
 namespace Strg.Integration.Tests.Middleware;
 
 /// <summary>
-/// STRG-010 TC-005 / TC-006 and the Security Review Checklist pin for "rate limit before auth".
+/// STRG-010 TC-005 / TC-006 + STRG-082 TC-001 / TC-002 / TC-003 / TC-004, plus the Security
+/// Review Checklist pin for "rate limit before auth".
 ///
 /// <para>
 /// All tests use a per-test <see cref="WebApplicationFactory{TEntryPoint}.WithWebHostBuilder"/>
@@ -112,6 +114,156 @@ public sealed class RateLimitingTests(StrgWebApplicationFactory factory) : IClas
             + "security-review ordering invariant (auth bypass via rate-limit exploit)");
     }
 
+    /// <summary>
+    /// STRG-082 TC-001 + AC1 + AC3 — bursts past the auth budget on <c>/connect/token</c> trip
+    /// the named "auth" policy and produce 429s with a <c>Retry-After</c> header and a JSON
+    /// error body. Runs with Auth=3 / Global=100000 so the auth limiter fires deterministically
+    /// before the global one in an 8-request burst. The first three requests reach the
+    /// OpenIddict token handler (returning 400 because the credentials are invalid — the
+    /// limiter is BEFORE auth, so credential validity doesn't gate budget consumption); from
+    /// the fourth onwards every response is a 429 with the rejection envelope.
+    /// </summary>
+    [Fact]
+    public async Task Auth_burst_exceeds_auth_budget_and_returns_429_with_retry_after()
+    {
+        const int permitLimit = 3;
+        const int burstSize = 8;
+        using var rateFactory = CreateFactoryWithAuthLimit(permitLimit, windowSeconds: 60);
+        using var client = rateFactory.CreateClient();
+
+        var statusCodes = new List<HttpStatusCode>();
+        HttpResponseMessage? lastRejection = null;
+        for (var i = 0; i < burstSize; i++)
+        {
+            using var form = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["grant_type"] = "password",
+                ["username"] = StrgWebApplicationFactory.AdminEmail,
+                ["password"] = "deliberately-wrong-password",
+                ["client_id"] = StrgWebApplicationFactory.DefaultClientId,
+                ["scope"] = StrgWebApplicationFactory.AdminScopes,
+            });
+            var response = await client.PostAsync("/connect/token", form);
+            statusCodes.Add(response.StatusCode);
+            if (response.StatusCode == HttpStatusCode.TooManyRequests && lastRejection is null)
+            {
+                lastRejection = response;
+            }
+            else
+            {
+                response.Dispose();
+            }
+        }
+
+        statusCodes.Should().Contain(HttpStatusCode.TooManyRequests,
+            $"sending {burstSize} token requests against an Auth={permitLimit}/min budget must overflow into 429");
+        statusCodes.Take(permitLimit).Should().NotContain(HttpStatusCode.TooManyRequests,
+            $"the first {permitLimit} requests within budget must reach the OpenIddict handler, not the limiter");
+
+        try
+        {
+            lastRejection.Should().NotBeNull("at least one request must have produced a 429 response");
+            lastRejection!.Headers.TryGetValues(HeaderNames.RetryAfter, out var retryValues).Should().BeTrue(
+                "every 429 must carry a Retry-After header per the Security Review Checklist");
+            var retryAfter = int.Parse(retryValues!.Single());
+            retryAfter.Should().BeGreaterThan(0, "Retry-After must be a positive integer second-count");
+
+            var body = await lastRejection.Content.ReadAsStringAsync();
+            body.Should().Contain("\"error\"",
+                "the rejection envelope is the {\"error\":\"...\"} JSON shape used by the rest of the API");
+        }
+        finally
+        {
+            lastRejection?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// STRG-082 TC-002 + AC2 — the global limiter rejects the request immediately following the
+    /// configured budget. Uses a small, deterministic budget rather than literally 300/301 so
+    /// the test runs sub-second; the boundary semantics are identical (N succeed-or-401, N+1th
+    /// is 429). Auth budget is left at the factory default (100000) so the named auth policy
+    /// can't shadow the global limit during the burst.
+    /// </summary>
+    [Fact]
+    public async Task Global_burst_returns_429_immediately_after_configured_budget()
+    {
+        const int permitLimit = 5;
+        const int burstSize = permitLimit + 3;
+        using var rateFactory = CreateFactoryWithGlobalLimit(permitLimit, windowSeconds: 60);
+        using var client = rateFactory.CreateClient();
+
+        var statusCodes = new List<HttpStatusCode>();
+        for (var i = 0; i < burstSize; i++)
+        {
+            using var response = await client.GetAsync("/api/v1/drives");
+            statusCodes.Add(response.StatusCode);
+        }
+
+        statusCodes.Take(permitLimit).Should().NotContain(HttpStatusCode.TooManyRequests,
+            $"the first {permitLimit} requests must reach the auth middleware (returning 401) — "
+            + "any 429 inside the budget means the limiter is rejecting under-budget traffic");
+        statusCodes.Skip(permitLimit).Should().Contain(HttpStatusCode.TooManyRequests,
+            $"requests {permitLimit + 1}..{burstSize} exhaust the global budget and must produce at least one 429");
+    }
+
+    /// <summary>
+    /// STRG-082 TC-003 + AC5 — <c>/health/live</c> is exempt from rate limiting. The K8s
+    /// liveness probe must never be starved of budget by other traffic; a 429 here would mark
+    /// the pod unhealthy and force a restart. Hammering 1000 times against a clamped budget
+    /// (3 permits / 1s window) proves the <c>.DisableRateLimiting()</c> wiring on the endpoint
+    /// keeps the limiter from ever firing on the probe.
+    /// </summary>
+    [Fact]
+    public async Task Liveness_probe_is_never_rate_limited_under_sustained_burst()
+    {
+        const int requestCount = 1000;
+        using var rateFactory = CreateFactoryWithGlobalLimit(permitLimit: 3, windowSeconds: 1);
+        using var client = rateFactory.CreateClient();
+
+        var statusCodes = new List<HttpStatusCode>();
+        for (var i = 0; i < requestCount; i++)
+        {
+            using var response = await client.GetAsync("/health/live");
+            statusCodes.Add(response.StatusCode);
+        }
+
+        statusCodes.Should().HaveCount(requestCount);
+        statusCodes.Should().AllSatisfy(s => s.Should().Be(HttpStatusCode.OK),
+            $"/health/live is mapped with .DisableRateLimiting() and must return 200 across all {requestCount} probes");
+    }
+
+    /// <summary>
+    /// STRG-082 TC-004 + AC6 — <c>appsettings.json</c> values flow through to the limiter
+    /// behavior. The same call shape with two different configured budgets must produce two
+    /// different breaking points. Verifies that the configured permit limit is the one the
+    /// limiter actually enforces (not a hardcoded constant), which is the audit thrust of the
+    /// Code Review Checklist's "Limits are configurable (not hardcoded)" item.
+    /// </summary>
+    [Theory]
+    [InlineData(2)]
+    [InlineData(7)]
+    public async Task Configured_global_limit_drives_observed_rejection_threshold(int permitLimit)
+    {
+        const int burstSize = 12;
+        using var rateFactory = CreateFactoryWithGlobalLimit(permitLimit, windowSeconds: 60);
+        using var client = rateFactory.CreateClient();
+
+        var rejectedAtIndex = -1;
+        for (var i = 0; i < burstSize; i++)
+        {
+            using var response = await client.GetAsync("/api/v1/drives");
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                rejectedAtIndex = i;
+                break;
+            }
+        }
+
+        rejectedAtIndex.Should().BeGreaterOrEqualTo(permitLimit,
+            $"the first 429 must appear at request index >= {permitLimit} (zero-based) when PermitLimit={permitLimit}");
+    }
+
     private WebApplicationFactory<Program> CreateFactoryWithGlobalLimit(int permitLimit, int windowSeconds) =>
         factory.WithWebHostBuilder(builder =>
         {
@@ -122,6 +274,20 @@ public sealed class RateLimitingTests(StrgWebApplicationFactory factory) : IClas
                     ["RateLimiting:Global:PermitLimit"] = permitLimit.ToString(),
                     ["RateLimiting:Global:WindowSeconds"] = windowSeconds.ToString(),
                     ["RateLimiting:Global:QueueLimit"] = "0",
+                });
+            });
+        });
+
+    private WebApplicationFactory<Program> CreateFactoryWithAuthLimit(int permitLimit, int windowSeconds) =>
+        factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["RateLimiting:Auth:PermitLimit"] = permitLimit.ToString(),
+                    ["RateLimiting:Auth:WindowSeconds"] = windowSeconds.ToString(),
+                    ["RateLimiting:Auth:QueueLimit"] = "0",
                 });
             });
         });


### PR DESCRIPTION
STRG-010 left the rate-limiter pipeline in place; STRG-082 closes the spec gaps.

- Global default lowered from 1000 → 300 req/min/IP (RateLimitOptions, appsettings)
- OnRejected handler emits a Retry-After header (sourced from lease metadata, fallback 60)
  and a {"error":"..."} JSON body matching the rest of the API
- Upload policy registered (per-user partition via JWT sub, IP fallback). Per spec body,
  TUS stays exempted in v0.1; the policy exists for future opt-in chunked-upload routes
- TODO marker for the v0.2 Redis-backed shared counter (STRG-117)
- Integration tests for TC-001/002/003/004 (auth burst with Retry-After + JSON body, global
  boundary, /health/live unbounded, configured-limit drives observed threshold)

Closes #21