### PR TITLE
feat(api): STRG-084 — extend security headers with CSP, cross-domain-policies, FLoC opt-out

### DIFF
--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -140,14 +140,15 @@ builder.Services.AddStrgRateLimiting(builder.Configuration);
 //
 // STRG-084 binds the values from the `Hsts` configuration section so operators can tune
 // MaxAge/IncludeSubDomains/Preload without rebuilds — the same pattern CORS uses for its
-// allow-list. `MaxAge` is read as integer seconds (matching RFC 6797's max-age directive
-// and the literal shape in the STRG-084 issue body) and converted to TimeSpan because
-// HstsOptions.MaxAge is a TimeSpan. When a key is absent the default matches the v0.1
-// security baseline so a missing or empty `Hsts` section is correct-by-omission.
+// allow-list. `MaxAge` is read as integer DAYS (the wire-level max-age directive is
+// seconds, but the config surface uses days because operators reason in calendar units —
+// "1 year" is 365, not 31_536_000) and converted to TimeSpan because HstsOptions.MaxAge
+// is a TimeSpan. When a key is absent the default matches the v0.1 security baseline so
+// a missing or empty `Hsts` section is correct-by-omission.
 builder.Services.Configure<Microsoft.AspNetCore.HttpsPolicy.HstsOptions>(options =>
 {
     var hsts = builder.Configuration.GetSection("Hsts");
-    options.MaxAge = TimeSpan.FromSeconds(hsts.GetValue<int>("MaxAge", 31_536_000));
+    options.MaxAge = TimeSpan.FromDays(hsts.GetValue<int>("MaxAge", 365));
     options.IncludeSubDomains = hsts.GetValue<bool>("IncludeSubDomains", true);
     options.Preload = hsts.GetValue<bool>("Preload", false);
 });

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -132,15 +132,24 @@ builder.Services.AddStrgOpenApi();
 builder.Services.AddStrgCors(builder.Configuration);
 builder.Services.AddStrgRateLimiting(builder.Configuration);
 
-// HSTS values per STRG-010 AC2: max-age=31536000 (1 year), includeSubDomains, preload NOT set
-// (security-review checklist: "HSTS preload is NOT set (risky for new domains)"). The default
-// MaxAge is 30 days — too low for the issue's "(max-age=31536000; includeSubDomains)" pin —
-// so this override is load-bearing. UseHsts itself remains env-gated below.
+// HSTS values per STRG-010 AC2 + STRG-084: max-age=31536000 (1 year), includeSubDomains,
+// preload NOT set (security-review checklist: "HSTS preload is NOT set (risky for new
+// domains)"). The framework default MaxAge is 30 days — too low for the issue's
+// "(max-age=31536000; includeSubDomains)" pin — so the override below is load-bearing.
+// UseHsts itself remains env-gated further down.
+//
+// STRG-084 binds the values from the `Hsts` configuration section so operators can tune
+// MaxAge/IncludeSubDomains/Preload without rebuilds — the same pattern CORS uses for its
+// allow-list. `MaxAge` is read as integer seconds (matching RFC 6797's max-age directive
+// and the literal shape in the STRG-084 issue body) and converted to TimeSpan because
+// HstsOptions.MaxAge is a TimeSpan. When a key is absent the default matches the v0.1
+// security baseline so a missing or empty `Hsts` section is correct-by-omission.
 builder.Services.Configure<Microsoft.AspNetCore.HttpsPolicy.HstsOptions>(options =>
 {
-    options.MaxAge = TimeSpan.FromDays(365);
-    options.IncludeSubDomains = true;
-    options.Preload = false;
+    var hsts = builder.Configuration.GetSection("Hsts");
+    options.MaxAge = TimeSpan.FromSeconds(hsts.GetValue<int>("MaxAge", 31_536_000));
+    options.IncludeSubDomains = hsts.GetValue<bool>("IncludeSubDomains", true);
+    options.Preload = hsts.GetValue<bool>("Preload", false);
 });
 
 // Storage providers (STRG-021/023/024). AddStrgStorageProviders registers the singleton registry

--- a/src/Strg.Api/Security/SecurityHeadersMiddleware.cs
+++ b/src/Strg.Api/Security/SecurityHeadersMiddleware.cs
@@ -4,10 +4,11 @@ using Strg.Core.Constants;
 namespace Strg.Api.Security;
 
 /// <summary>
-/// Applies the strg security response-header set to every HTTP response (STRG-010). Registered
-/// via <see cref="UseStrgSecurityHeaders(IApplicationBuilder)"/> and wired in <c>Program.cs</c>
-/// BEFORE the <c>/dav</c> map and <c>UseStrgOpenApi</c> so short-circuiting middleware further
-/// down the pipeline (Swashbuckle's spec endpoints, WebDAV verb handlers) still emit the headers.
+/// Applies the strg security response-header set to every HTTP response (STRG-010 + STRG-084).
+/// Registered via <see cref="UseStrgSecurityHeaders(IApplicationBuilder)"/> and wired in
+/// <c>Program.cs</c> BEFORE the <c>/dav</c> map and <c>UseStrgOpenApi</c> so short-circuiting
+/// middleware further down the pipeline (Swashbuckle's spec endpoints, WebDAV verb handlers)
+/// still emit the headers.
 ///
 /// <para>
 /// Headers are attached via <see cref="HttpResponse.OnStarting(Func{object, Task}, object)"/>
@@ -18,13 +19,42 @@ namespace Strg.Api.Security;
 /// fires at the moment headers are about to be written, which is the only reliable moment to
 /// stamp them on every response the pipeline can produce.
 /// </para>
+///
+/// <para>
+/// STRG-084 adds three headers on top of the STRG-010 baseline: a <c>default-src 'none'</c>
+/// Content Security Policy with <c>frame-ancestors 'none'</c>, a legacy
+/// <c>X-Permitted-Cross-Domain-Policies: none</c> directive, and the
+/// <c>interest-cohort=()</c> token in <c>Permissions-Policy</c> to opt out of the FLoC /
+/// Topics API on every response. The CSP is scoped for a pure-API host: every directive
+/// inherits <c>'none'</c> via <c>default-src</c>, so any browser that lands on a strg
+/// response cannot fetch scripts, stylesheets, images, or fonts. The Swagger UI is the only
+/// HTML surface strg serves and it uses inline scripts that this CSP blocks — the
+/// development-time UX hit is intentional per the issue ("API-specific CSP: no scripts, no
+/// inline, no iframes"); operators who need an interactive UI can override CSP for
+/// <c>/openapi/ui</c> in their own deployment.
+/// </para>
 /// </summary>
 internal static class SecurityHeadersMiddleware
 {
     private const string XContentTypeOptionsValue = "nosniff";
     private const string XFrameOptionsValue = "DENY";
     private const string ReferrerPolicyValue = "strict-origin-when-cross-origin";
-    private const string PermissionsPolicyValue = "geolocation=(), microphone=(), camera=()";
+
+    // STRG-084 — interest-cohort opts out of FLoC / Topics API cohort calculations on this
+    // origin. Browsers that ignored Permissions-Policy for cohort assignment have all been
+    // retired, but the directive remains the canonical opt-out signal.
+    private const string PermissionsPolicyValue =
+        "camera=(), microphone=(), geolocation=(), interest-cohort=()";
+
+    // STRG-084 — strict default-src 'none' is the API-host shape. frame-ancestors 'none'
+    // duplicates the X-Frame-Options: DENY guarantee for browsers that honour CSP but not
+    // the legacy header (Safari < 15.4 in particular). The trailing semicolon mirrors the
+    // issue spec verbatim.
+    private const string ContentSecurityPolicyValue = "default-src 'none'; frame-ancestors 'none';";
+
+    // STRG-084 — bars Adobe Flash / Acrobat plug-ins from honouring any cross-domain policy
+    // file. Defence-in-depth against legacy clients that still consult crossdomain.xml.
+    private const string XPermittedCrossDomainPoliciesValue = "none";
 
     /// <summary>
     /// Registers the strg security-header middleware. See the type-level remarks for the
@@ -45,6 +75,8 @@ internal static class SecurityHeadersMiddleware
                 headers[HeaderNames.XFrameOptions] = XFrameOptionsValue;
                 headers[StrgHeaderNames.ReferrerPolicy] = ReferrerPolicyValue;
                 headers[StrgHeaderNames.PermissionsPolicy] = PermissionsPolicyValue;
+                headers[HeaderNames.ContentSecurityPolicy] = ContentSecurityPolicyValue;
+                headers[StrgHeaderNames.XPermittedCrossDomainPolicies] = XPermittedCrossDomainPoliciesValue;
 
                 // Defence-in-depth strip. Kestrel's default Server header is suppressed at the
                 // host level (ConfigureKestrel(AddServerHeader=false) in Program.cs); removing

--- a/src/Strg.Api/appsettings.json
+++ b/src/Strg.Api/appsettings.json
@@ -19,6 +19,11 @@
   "Cors": {
     "AllowedOrigins": []
   },
+  "Hsts": {
+    "MaxAge": 31536000,
+    "IncludeSubDomains": true,
+    "Preload": false
+  },
   "RateLimiting": {
     "Auth": { "PermitLimit": 10, "WindowSeconds": 60, "QueueLimit": 0 },
     "Global": { "PermitLimit": 300, "WindowSeconds": 60, "QueueLimit": 0 },

--- a/src/Strg.Api/appsettings.json
+++ b/src/Strg.Api/appsettings.json
@@ -20,7 +20,7 @@
     "AllowedOrigins": []
   },
   "Hsts": {
-    "MaxAge": 31536000,
+    "MaxAge": 365,
     "IncludeSubDomains": true,
     "Preload": false
   },

--- a/src/Strg.Core/Constants/StrgHeaderNames.cs
+++ b/src/Strg.Core/Constants/StrgHeaderNames.cs
@@ -28,4 +28,15 @@ public static class StrgHeaderNames
     /// document may invoke. Not exposed by <c>Microsoft.Net.Http.Headers.HeaderNames</c>.
     /// </summary>
     public const string PermissionsPolicy = "Permissions-Policy";
+
+    /// <summary>
+    /// <c>X-Permitted-Cross-Domain-Policies</c> response header (STRG-084). Legacy Adobe
+    /// Flash/Acrobat directive; the value <c>none</c> bars cross-domain policy files
+    /// (<c>crossdomain.xml</c>, <c>clientaccesspolicy.xml</c>) from being honoured by any
+    /// runtime that consults them. Even though Flash and the Acrobat browser plug-in are
+    /// long-deprecated, the header remains a defence-in-depth signal because PDF readers and
+    /// older corporate plug-ins still parse it. Absent from
+    /// <c>Microsoft.Net.Http.Headers.HeaderNames</c>.
+    /// </summary>
+    public const string XPermittedCrossDomainPolicies = "X-Permitted-Cross-Domain-Policies";
 }

--- a/tests/Strg.Integration.Tests/Middleware/SecurityHeadersTests.cs
+++ b/tests/Strg.Integration.Tests/Middleware/SecurityHeadersTests.cs
@@ -8,19 +8,28 @@ using Xunit;
 namespace Strg.Integration.Tests.Middleware;
 
 /// <summary>
-/// STRG-010 TC-002 + AC3/AC4 + Security Review Checklist pins. Drives the real ASP.NET Core
-/// pipeline through <see cref="StrgWebApplicationFactory"/> so the assertions cover the
-/// production middleware wiring (<c>UseStrgSecurityHeaders</c> before <c>UseStrgOpenApi</c>
-/// and the <c>/dav</c> map, <c>ConfigureKestrel(AddServerHeader=false)</c>) — NOT a hand-rolled
-/// minimal host.
+/// STRG-010 TC-002 + AC3/AC4 + STRG-084 TC-001 + Security Review Checklist pins. Drives the
+/// real ASP.NET Core pipeline through <see cref="StrgWebApplicationFactory"/> so the
+/// assertions cover the production middleware wiring (<c>UseStrgSecurityHeaders</c> before
+/// <c>UseStrgOpenApi</c> and the <c>/dav</c> map, <c>ConfigureKestrel(AddServerHeader=false)</c>)
+/// — NOT a hand-rolled minimal host.
 /// </summary>
 public sealed class SecurityHeadersTests(StrgWebApplicationFactory factory) : IClassFixture<StrgWebApplicationFactory>
 {
     /// <summary>
-    /// TC-002 + AC3 — <c>X-Content-Type-Options: nosniff</c> is present on every response,
-    /// including short-circuiting ones (Swagger spec, health probes, the anonymous token
-    /// endpoint failure path). The theory probes multiple surfaces so a regression that
-    /// narrows the middleware's reach to only one branch fails here.
+    /// STRG-010 TC-002 + STRG-084 TC-001 + STRG-084 AC1/AC2 — every API response carries the
+    /// strg security-header set, including short-circuiting ones (Swagger spec, health probes,
+    /// the anonymous token endpoint failure path). The theory probes multiple surfaces so a
+    /// regression that narrows the middleware's reach to only one branch fails here.
+    ///
+    /// <para>
+    /// The assertion set covers BOTH the STRG-010 baseline (X-Content-Type-Options,
+    /// X-Frame-Options, Referrer-Policy, Permissions-Policy) AND the STRG-084 additions
+    /// (Content-Security-Policy with <c>default-src 'none'; frame-ancestors 'none';</c> and
+    /// <c>X-Permitted-Cross-Domain-Policies: none</c>). Permissions-Policy is checked for
+    /// BOTH <c>camera=()</c> (STRG-010 baseline) and <c>interest-cohort=()</c> (STRG-084
+    /// FLoC/Topics opt-out) so a regression that drops either token surfaces here.
+    /// </para>
     /// </summary>
     [Theory]
     [InlineData("/health/live")]
@@ -37,11 +46,11 @@ public sealed class SecurityHeadersTests(StrgWebApplicationFactory factory) : IC
         // contract is the same regardless of status; OnStarting fires before the response
         // body flushes.
         response.Headers.TryGetValues(HeaderNames.XContentTypeOptions, out var nosniff).Should().BeTrue(
-            $"'{path}' response must carry X-Content-Type-Options per STRG-010 AC3");
+            $"'{path}' response must carry X-Content-Type-Options per STRG-010 AC3 / STRG-084 AC1");
         nosniff!.Single().Should().Be("nosniff");
 
         response.Headers.TryGetValues(HeaderNames.XFrameOptions, out var frameOptions).Should().BeTrue(
-            $"'{path}' response must carry X-Frame-Options per STRG-010 AC4");
+            $"'{path}' response must carry X-Frame-Options per STRG-010 AC4 / STRG-084 AC2");
         frameOptions!.Single().Should().Be("DENY");
 
         response.Headers.TryGetValues(StrgHeaderNames.ReferrerPolicy, out var referrer).Should().BeTrue(
@@ -50,8 +59,27 @@ public sealed class SecurityHeadersTests(StrgWebApplicationFactory factory) : IC
 
         response.Headers.TryGetValues(StrgHeaderNames.PermissionsPolicy, out var permissions).Should().BeTrue(
             $"'{path}' response must carry Permissions-Policy");
-        permissions!.Single().Should().Contain("camera=()",
+        var permissionsValue = permissions!.Single();
+        permissionsValue.Should().Contain("camera=()",
             "the Permissions-Policy value locks down camera/microphone/geolocation per STRG-010");
+        permissionsValue.Should().Contain("interest-cohort=()",
+            "STRG-084 adds the FLoC/Topics opt-out token to Permissions-Policy");
+
+        // STRG-084 — strict CSP applied to every response. The pin checks for the literal
+        // value because both directives are load-bearing: default-src 'none' blocks every
+        // resource fetch, frame-ancestors 'none' duplicates X-Frame-Options for browsers
+        // that honour CSP but not the legacy header. A relaxed default-src would silently
+        // pass a startsWith check, hence the full-string assertion.
+        response.Headers.TryGetValues(HeaderNames.ContentSecurityPolicy, out var csp).Should().BeTrue(
+            $"'{path}' response must carry Content-Security-Policy per STRG-084 spec");
+        csp!.Single().Should().Be("default-src 'none'; frame-ancestors 'none';",
+            "STRG-084 fixes the API-host CSP to default-src 'none' + frame-ancestors 'none'");
+
+        // STRG-084 — defence-in-depth against legacy Flash/Acrobat plug-ins that consult
+        // crossdomain.xml.
+        response.Headers.TryGetValues(StrgHeaderNames.XPermittedCrossDomainPolicies, out var crossDomain).Should().BeTrue(
+            $"'{path}' response must carry X-Permitted-Cross-Domain-Policies per STRG-084 spec");
+        crossDomain!.Single().Should().Be("none");
     }
 
     /// <summary>
@@ -98,6 +126,9 @@ public sealed class SecurityHeadersTests(StrgWebApplicationFactory factory) : IC
     /// <c>UseStrgOpenApi</c> so the Swashbuckle short-circuit response (spec JSON) still
     /// carries the full header set. Swashbuckle writes the response synchronously and the
     /// <c>OnStarting</c>-based middleware is the only placement that survives that pattern.
+    /// STRG-084 widens this pin to the CSP + X-Permitted-Cross-Domain-Policies additions so a
+    /// future contributor who moves the security-headers middleware AFTER the OpenAPI
+    /// middleware would surface that regression specifically on this short-circuit path.
     /// </summary>
     [Fact]
     public async Task Openapi_spec_response_carries_security_headers()
@@ -109,5 +140,9 @@ public sealed class SecurityHeadersTests(StrgWebApplicationFactory factory) : IC
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Headers.GetValues(HeaderNames.XContentTypeOptions).Single().Should().Be("nosniff");
         response.Headers.GetValues(HeaderNames.XFrameOptions).Single().Should().Be("DENY");
+        response.Headers.GetValues(HeaderNames.ContentSecurityPolicy).Single()
+            .Should().Be("default-src 'none'; frame-ancestors 'none';");
+        response.Headers.GetValues(StrgHeaderNames.XPermittedCrossDomainPolicies).Single()
+            .Should().Be("none");
     }
 }


### PR DESCRIPTION
STRG-010 wired the HSTS / Server-suppression / CORS baseline; STRG-084 layers
the API-host CSP (`default-src 'none'; frame-ancestors 'none';`), the legacy
`X-Permitted-Cross-Domain-Policies: none` directive, and the `interest-cohort=()`
Permissions-Policy token onto every response. HstsOptions now binds from the
`Hsts` configuration section (with spec defaults) so MaxAge / IncludeSubDomains /
Preload are operator-tunable without rebuilds — the same pattern CORS uses for
its allow-list. Integration tests in SecurityHeadersTests pin the literal CSP
value and the cross-domain-policies header on every probed surface so a future
contributor relaxing either directive surfaces the regression on the Theory.

https://claude.ai/code/session_01XZghkFcYfvQDVNcASfwXN3