### PR TITLE
feat(api): STRG-085 — FluentValidation request-body validation with RFC 7807 envelope

### DIFF
--- a/src/Strg.Api/Endpoints/FileCopyEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileCopyEndpoints.cs
@@ -46,10 +46,13 @@ public static class FileCopyEndpoints
                 "FileItem on 201 Created with a Location header pointing at the new file. The " +
                 "source file is never touched. A new FileVersion (version 1) is always created " +
                 "for the copy. Quota is reserved against the caller's user before bytes are " +
-                "relocated; insufficient storage returns 507. Path traversal or other malformed " +
-                "TargetPath returns 400 InvalidPath; an existing file at the target path returns " +
-                "409 Conflict; files in another drive collapse to 404. Directory copy returns 400 " +
-                "DirectoryCopyUnsupported in v1.5 — see follow-up issue.");
+                "relocated; insufficient storage returns 507. Empty TargetPath or one containing " +
+                "'..' is rejected by the request-body validator with 400 and an RFC 7807 " +
+                "ValidationProblemDetails envelope. Other malformed TargetPath the validator " +
+                "doesn't catch (reserved names, null bytes) is rejected by the handler with 400 " +
+                "and a {code:'InvalidPath',message} envelope. An existing file at the target " +
+                "path returns 409 Conflict; files in another drive collapse to 404. Directory " +
+                "copy returns 400 DirectoryCopyUnsupported in v1.5 — see follow-up issue.");
 
         return app;
     }

--- a/src/Strg.Api/Endpoints/FileCopyEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileCopyEndpoints.cs
@@ -1,5 +1,6 @@
 using Mediator;
 using Strg.Api.Auth;
+using Strg.Api.Validators;
 using Strg.Application.Features.Files.Copy;
 using Strg.Core;
 using Strg.Core.Domain;
@@ -36,6 +37,7 @@ public static class FileCopyEndpoints
     {
         app.MapPost("/api/v1/drives/{driveId:guid}/files/{fileId:guid}/copy", CopyFileAsync)
             .RequireAuthorization(AuthPolicies.FilesWrite)
+            .AddEndpointFilter<ValidationProblemDetailsFilter<CopyFileRequest>>()
             .WithName("CopyFile")
             .WithTags("Files")
             .WithSummary("Copy a file to a new path, optionally across drives.")

--- a/src/Strg.Api/Endpoints/FileMoveEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileMoveEndpoints.cs
@@ -38,11 +38,14 @@ public static class FileMoveEndpoints
                 "on 200 OK. Within-drive moves (file or directory) are pure metadata mutations — " +
                 "the bytes never relocate. Cross-drive single-file moves copy the bytes onto the " +
                 "target drive and delete the source (best-effort). Cross-drive directory moves " +
-                "return 400 CrossDriveDirectoryUnsupported in v1.5 — see follow-up issue. Path " +
-                "traversal or other malformed TargetPath returns 400 InvalidPath; an existing " +
-                "file at the target path or descendant within the target directory prefix " +
-                "returns 409 Conflict; files in another drive collapse to 404 (deliberately, to " +
-                "prevent cross-drive enumeration).");
+                "return 400 CrossDriveDirectoryUnsupported in v1.5 — see follow-up issue. Empty " +
+                "TargetPath or one containing '..' is rejected by the request-body validator " +
+                "with 400 and an RFC 7807 ValidationProblemDetails envelope. Other malformed " +
+                "TargetPath the validator doesn't catch (reserved names, null bytes) is rejected " +
+                "by the handler with 400 and a {code:'InvalidPath',message} envelope. An " +
+                "existing file at the target path or descendant within the target directory " +
+                "prefix returns 409 Conflict; files in another drive collapse to 404 " +
+                "(deliberately, to prevent cross-drive enumeration).");
 
         return app;
     }

--- a/src/Strg.Api/Endpoints/FileMoveEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FileMoveEndpoints.cs
@@ -1,5 +1,6 @@
 using Mediator;
 using Strg.Api.Auth;
+using Strg.Api.Validators;
 using Strg.Application.Features.Files.Move;
 using Strg.Core.Domain;
 
@@ -28,6 +29,7 @@ public static class FileMoveEndpoints
     {
         app.MapPost("/api/v1/drives/{driveId:guid}/files/{fileId:guid}/move", MoveFileAsync)
             .RequireAuthorization(AuthPolicies.FilesWrite)
+            .AddEndpointFilter<ValidationProblemDetailsFilter<MoveFileRequest>>()
             .WithName("MoveFile")
             .WithTags("Files")
             .WithSummary("Move a file or directory to a new path, optionally across drives.")

--- a/src/Strg.Api/Endpoints/FolderCreateEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FolderCreateEndpoints.cs
@@ -1,5 +1,6 @@
 using Mediator;
 using Strg.Api.Auth;
+using Strg.Api.Validators;
 using Strg.Application.Features.Folders.Create;
 using Strg.Core;
 using Strg.Core.Domain;
@@ -38,6 +39,7 @@ public static class FolderCreateEndpoints
     {
         app.MapPost("/api/v1/drives/{driveId:guid}/folders", CreateFolderAsync)
             .RequireAuthorization(AuthPolicies.FilesWrite)
+            .AddEndpointFilter<ValidationProblemDetailsFilter<CreateFolderRequest>>()
             .WithName("CreateFolder")
             .WithTags("Files")
             .WithSummary("Create a directory FileItem at a virtual path; auto-creates missing parent segments.")

--- a/src/Strg.Api/Endpoints/FolderCreateEndpoints.cs
+++ b/src/Strg.Api/Endpoints/FolderCreateEndpoints.cs
@@ -48,10 +48,13 @@ public static class FolderCreateEndpoints
                 "yet are auto-created in order, with ParentId chained to the previous segment, " +
                 "so a single call materializes the entire path. The call is idempotent: re-POSTing " +
                 "the same path returns the existing folder row with no duplicate. A path segment " +
-                "that already exists as a non-directory FILE returns 409 Conflict. Path traversal, " +
-                "reserved names, or other malformed input return 400 InvalidPath. A missing target " +
-                "drive returns 404. No physical directory is created in the storage backend — " +
-                "strg uses virtual paths and a flat blob store.");
+                "that already exists as a non-directory FILE returns 409 Conflict. Empty path or " +
+                "path containing '..' is rejected by the request-body validator with 400 and an " +
+                "RFC 7807 ValidationProblemDetails envelope. Other malformed input the validator " +
+                "doesn't catch (reserved names, null bytes) is rejected by the handler with 400 " +
+                "and a {code:'InvalidPath',message} envelope. A missing target drive returns 404. " +
+                "No physical directory is created in the storage backend — strg uses virtual " +
+                "paths and a flat blob store.");
 
         return app;
     }

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -118,6 +118,14 @@ builder.Services.AddStrgWebDav(builder.Configuration);
 // validated endpoints) can resolve IValidator<T> from DI without hand-wiring each.
 builder.Services.AddValidatorsFromAssemblyContaining<Program>();
 
+// AddFluentValidationAutoValidation hooks into MVC's IModelBinder pipeline; the API surface here
+// is minimal-API only (RequestDelegateFactory binds bodies, MVC never runs), so this call is a
+// no-op for current routes. Registered for forward compatibility — if MVC controllers are ever
+// added, validators auto-trigger without an extra wiring step. The load-bearing surface for
+// minimal-API endpoints is the per-route ValidationProblemDetailsFilter<TRequest> filter wired
+// in MapFolderCreateEndpoints / MapFileMoveEndpoints / MapFileCopyEndpoints.
+builder.Services.AddFluentValidationAutoValidation();
+
 // ---- OpenAPI / Swagger (STRG-009) ----
 // Spec + UI wiring. The UI is gated by environment in UseStrgOpenApi below; registration of
 // the generator itself is always on so the JSON/YAML endpoints work in production.

--- a/src/Strg.Api/Validators/CopyFileRequestValidator.cs
+++ b/src/Strg.Api/Validators/CopyFileRequestValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using Strg.Api.Endpoints;
+
+namespace Strg.Api.Validators;
+
+/// <summary>
+/// STRG-085 — request-body validator for <see cref="CopyFileRequest"/>. Runs as a minimal-API
+/// endpoint filter (<see cref="ValidationProblemDetailsFilter{TRequest}"/>) BEFORE the mediator
+/// dispatch; on failure the response is RFC 7807 <c>ValidationProblemDetails</c> (HTTP 400).
+///
+/// <para>Path traversal (<c>..</c>) is blocked here AND inside the handler via
+/// <see cref="Strg.Core.Storage.StoragePath.Parse"/> — see the belt-and-suspenders rationale on
+/// <see cref="ValidationProblemDetailsFilter{TRequest}"/>.</para>
+/// </summary>
+public sealed class CopyFileRequestValidator : AbstractValidator<CopyFileRequest>
+{
+    public CopyFileRequestValidator()
+    {
+        RuleFor(x => x.TargetPath)
+            .NotEmpty()
+            .WithMessage("TargetPath is required.")
+            .MaximumLength(4096)
+            .Must(p => p is null || !p.Contains("..", StringComparison.Ordinal))
+            .WithMessage("TargetPath must not contain '..'.");
+    }
+}

--- a/src/Strg.Api/Validators/CreateFolderRequestValidator.cs
+++ b/src/Strg.Api/Validators/CreateFolderRequestValidator.cs
@@ -1,0 +1,27 @@
+using FluentValidation;
+using Strg.Api.Endpoints;
+
+namespace Strg.Api.Validators;
+
+/// <summary>
+/// STRG-085 — request-body validator for <see cref="CreateFolderRequest"/>. Runs as a minimal-API
+/// endpoint filter (<see cref="ValidationProblemDetailsFilter{TRequest}"/>) BEFORE the mediator
+/// dispatch; on failure the response is RFC 7807 <c>ValidationProblemDetails</c> (HTTP 400).
+///
+/// <para>Path traversal (<c>..</c>) is blocked here AND inside the handler via
+/// <see cref="Strg.Core.Storage.StoragePath.Parse"/> — see the belt-and-suspenders rationale on
+/// <see cref="ValidationProblemDetailsFilter{TRequest}"/>. The 4096-character cap mirrors the
+/// issue spec and prevents oversized request bodies from reaching EF Core.</para>
+/// </summary>
+public sealed class CreateFolderRequestValidator : AbstractValidator<CreateFolderRequest>
+{
+    public CreateFolderRequestValidator()
+    {
+        RuleFor(x => x.Path)
+            .NotEmpty()
+            .WithMessage("Path is required.")
+            .MaximumLength(4096)
+            .Must(p => p is null || !p.Contains("..", StringComparison.Ordinal))
+            .WithMessage("Path must not contain '..'.");
+    }
+}

--- a/src/Strg.Api/Validators/MoveFileRequestValidator.cs
+++ b/src/Strg.Api/Validators/MoveFileRequestValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+using Strg.Api.Endpoints;
+
+namespace Strg.Api.Validators;
+
+/// <summary>
+/// STRG-085 — request-body validator for <see cref="MoveFileRequest"/>. Runs as a minimal-API
+/// endpoint filter (<see cref="ValidationProblemDetailsFilter{TRequest}"/>) BEFORE the mediator
+/// dispatch; on failure the response is RFC 7807 <c>ValidationProblemDetails</c> (HTTP 400).
+///
+/// <para>Path traversal (<c>..</c>) is blocked here AND inside the handler via
+/// <see cref="Strg.Core.Storage.StoragePath.Parse"/> — see the belt-and-suspenders rationale on
+/// <see cref="ValidationProblemDetailsFilter{TRequest}"/>.</para>
+/// </summary>
+public sealed class MoveFileRequestValidator : AbstractValidator<MoveFileRequest>
+{
+    public MoveFileRequestValidator()
+    {
+        RuleFor(x => x.TargetPath)
+            .NotEmpty()
+            .WithMessage("TargetPath is required.")
+            .MaximumLength(4096)
+            .Must(p => p is null || !p.Contains("..", StringComparison.Ordinal))
+            .WithMessage("TargetPath must not contain '..'.");
+    }
+}

--- a/src/Strg.Api/Validators/ValidationProblemDetailsFilter.cs
+++ b/src/Strg.Api/Validators/ValidationProblemDetailsFilter.cs
@@ -29,9 +29,17 @@ namespace Strg.Api.Validators;
 /// non-HTTP caller (e.g. internal CLI, GraphQL mutation that bypasses this filter) still goes
 /// through <c>Parse</c>; the filter is the front-door enforcement, <c>Parse</c> is the
 /// last-line-of-defence guard.</para>
+///
+/// <para><b>Missing-validator policy.</b> A missing <see cref="IValidator{TRequest}"/>
+/// registration is treated as a configuration bug: the filter is wired explicitly per route, so
+/// a forgotten DI registration would otherwise ship to production with zero shape-level
+/// enforcement. The filter throws <see cref="InvalidOperationException"/> on the first request
+/// instead — surfacing the misconfig loudly via the global problem-details middleware rather
+/// than silently relying on <c>StoragePath.Parse</c> to catch what a deleted validator would
+/// have rejected.</para>
 /// </summary>
 public sealed class ValidationProblemDetailsFilter<TRequest> : IEndpointFilter
-    where TRequest : notnull
+    where TRequest : class
 {
     public async ValueTask<object?> InvokeAsync(
         EndpointFilterInvocationContext context,
@@ -40,22 +48,20 @@ public sealed class ValidationProblemDetailsFilter<TRequest> : IEndpointFilter
         // Locate the request body in the bound argument list. Minimal API parameter binding
         // produces the body as one of the arguments at a position the framework picks; OfType
         // avoids a brittle index assumption and tolerates additional arguments (route values,
-        // injected services).
+        // injected services). A null result means the route does not bind a TRequest body
+        // (e.g. only route values / query parameters) — pass through.
         var request = context.Arguments.OfType<TRequest>().FirstOrDefault();
         if (request is null)
         {
             return await next(context);
         }
 
-        var validator = context.HttpContext.RequestServices.GetService<IValidator<TRequest>>();
-        if (validator is null)
-        {
-            // No validator registered for TRequest → behave as a no-op, NOT a failure. Matches
-            // FluentValidation.AspNetCore's "validators are optional" semantics so adding the
-            // filter to a route whose request type has no validator yet does not produce a
-            // surprise 500.
-            return await next(context);
-        }
+        var validator = context.HttpContext.RequestServices.GetService<IValidator<TRequest>>()
+            ?? throw new InvalidOperationException(
+                $"No IValidator<{typeof(TRequest).Name}> is registered. " +
+                $"ValidationProblemDetailsFilter<{typeof(TRequest).Name}> requires a corresponding validator " +
+                "to be registered via AddValidatorsFromAssemblyContaining<>(). Remove the filter " +
+                "from the endpoint or add the missing validator.");
 
         var result = await validator.ValidateAsync(request, context.HttpContext.RequestAborted);
         if (result.IsValid)

--- a/src/Strg.Api/Validators/ValidationProblemDetailsFilter.cs
+++ b/src/Strg.Api/Validators/ValidationProblemDetailsFilter.cs
@@ -1,0 +1,92 @@
+using FluentValidation;
+
+namespace Strg.Api.Validators;
+
+/// <summary>
+/// STRG-085 — generic <see cref="IEndpointFilter"/> that runs the registered
+/// <see cref="IValidator{TRequest}"/> against the matching argument in the endpoint's parameter
+/// list and surfaces failures as RFC 7807 <c>ValidationProblemDetails</c> (HTTP 400). Wire it via
+/// <c>.AddEndpointFilter&lt;ValidationProblemDetailsFilter&lt;TRequest&gt;&gt;()</c> on minimal-API
+/// routes whose body type is <typeparamref name="TRequest"/>.
+///
+/// <para><b>Why a filter instead of <c>AddFluentValidationAutoValidation()</c>.</b> The package's
+/// auto-validation hooks into MVC's <c>IModelBinder</c> pipeline; minimal APIs (which this app
+/// uses end-to-end) bind via <c>RequestDelegateFactory</c> and never invoke the MVC pipeline. The
+/// auto-validator call is still registered in <c>Program.cs</c> for forward compatibility if any
+/// MVC controllers are ever added, but the load-bearing surface for minimal APIs is this
+/// per-endpoint filter.</para>
+///
+/// <para><b>Wire-shape contract.</b> <see cref="Results.ValidationProblem(IDictionary{string, string[]},string?,string?,int?,string?,string?,IDictionary{string, object?}?)"/>
+/// emits the RFC 7807 envelope the issue spec mandates: <c>type</c>, <c>title</c>,
+/// <c>status</c>, and an <c>errors</c> dictionary keyed by camel-cased property name. Property
+/// names are camel-cased here (not by ASP.NET Core) because FluentValidation's
+/// <c>ValidationFailure.PropertyName</c> mirrors the C# property casing — keeping the wire field
+/// names aligned with the JSON request body shape that callers actually submit.</para>
+///
+/// <para><b>Belt-and-suspenders.</b> This filter rejects shape-level violations (empty path,
+/// length cap, traversal token) BEFORE the handler runs, but path validation in the handler via
+/// <see cref="Strg.Core.Storage.StoragePath.Parse"/> is intentionally retained. A future
+/// non-HTTP caller (e.g. internal CLI, GraphQL mutation that bypasses this filter) still goes
+/// through <c>Parse</c>; the filter is the front-door enforcement, <c>Parse</c> is the
+/// last-line-of-defence guard.</para>
+/// </summary>
+public sealed class ValidationProblemDetailsFilter<TRequest> : IEndpointFilter
+    where TRequest : notnull
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        // Locate the request body in the bound argument list. Minimal API parameter binding
+        // produces the body as one of the arguments at a position the framework picks; OfType
+        // avoids a brittle index assumption and tolerates additional arguments (route values,
+        // injected services).
+        var request = context.Arguments.OfType<TRequest>().FirstOrDefault();
+        if (request is null)
+        {
+            return await next(context);
+        }
+
+        var validator = context.HttpContext.RequestServices.GetService<IValidator<TRequest>>();
+        if (validator is null)
+        {
+            // No validator registered for TRequest → behave as a no-op, NOT a failure. Matches
+            // FluentValidation.AspNetCore's "validators are optional" semantics so adding the
+            // filter to a route whose request type has no validator yet does not produce a
+            // surprise 500.
+            return await next(context);
+        }
+
+        var result = await validator.ValidateAsync(request, context.HttpContext.RequestAborted);
+        if (result.IsValid)
+        {
+            return await next(context);
+        }
+
+        var errors = result.Errors
+            .GroupBy(e => CamelCase(e.PropertyName))
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(e => e.ErrorMessage).ToArray());
+
+        return Results.ValidationProblem(
+            errors,
+            title: "Validation failed",
+            type: "https://tools.ietf.org/html/rfc7807");
+    }
+
+    private static string CamelCase(string propertyName)
+    {
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return propertyName;
+        }
+
+        if (!char.IsUpper(propertyName[0]))
+        {
+            return propertyName;
+        }
+
+        return char.ToLowerInvariant(propertyName[0]) + propertyName[1..];
+    }
+}

--- a/tests/Strg.Api.Tests/Strg.Api.Tests.csproj
+++ b/tests/Strg.Api.Tests/Strg.Api.Tests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="xunit" />

--- a/tests/Strg.Api.Tests/Validators/CopyFileRequestValidatorTests.cs
+++ b/tests/Strg.Api.Tests/Validators/CopyFileRequestValidatorTests.cs
@@ -1,0 +1,73 @@
+using FluentValidation.TestHelper;
+using Strg.Api.Endpoints;
+using Strg.Api.Validators;
+using Xunit;
+
+namespace Strg.Api.Tests.Validators;
+
+/// <summary>
+/// STRG-085 — unit tests for <see cref="CopyFileRequestValidator"/>. Rules are isomorphic to
+/// MoveFileRequestValidator's (the request shapes only differ in semantic, not in the
+/// path-validation contract); the duplicated test methods serve as the regression pin in case
+/// future evolution decouples the two validators (e.g. cross-drive copy adds a CopyFile-specific
+/// constraint that move doesn't have).
+/// </summary>
+public sealed class CopyFileRequestValidatorTests
+{
+    private readonly CopyFileRequestValidator _validator = new();
+
+    [Fact]
+    public void EmptyTargetPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new CopyFileRequest(string.Empty, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath is required.");
+    }
+
+    [Fact]
+    public void NullTargetPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new CopyFileRequest(null!, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath is required.");
+    }
+
+    [Fact]
+    public void ValidTargetPath_Passes()
+    {
+        var result = _validator.TestValidate(new CopyFileRequest("a/b/c.txt", null));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetPath);
+    }
+
+    [Fact]
+    public void TraversalTargetPath_Fails()
+    {
+        var result = _validator.TestValidate(new CopyFileRequest("../../etc/passwd", null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath must not contain '..'.");
+    }
+
+    [Fact]
+    public void TargetPathExceeding4096Chars_Fails()
+    {
+        var longPath = new string('a', 4097);
+
+        var result = _validator.TestValidate(new CopyFileRequest(longPath, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath);
+    }
+
+    [Fact]
+    public void TargetPathAtMaximumLength_Passes()
+    {
+        var maxPath = new string('a', 4096);
+
+        var result = _validator.TestValidate(new CopyFileRequest(maxPath, null));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetPath);
+    }
+}

--- a/tests/Strg.Api.Tests/Validators/CreateFolderRequestValidatorTests.cs
+++ b/tests/Strg.Api.Tests/Validators/CreateFolderRequestValidatorTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Strg.Api.Endpoints;
+using Strg.Api.Validators;
+using Xunit;
+
+namespace Strg.Api.Tests.Validators;
+
+/// <summary>
+/// STRG-085 — unit tests for <see cref="CreateFolderRequestValidator"/>. Each rule is exercised
+/// in isolation; integration coverage of the wire-level RFC 7807 envelope lives in
+/// <c>Strg.Integration.Tests</c>.
+/// </summary>
+public sealed class CreateFolderRequestValidatorTests
+{
+    private readonly CreateFolderRequestValidator _validator = new();
+
+    [Fact]
+    public void EmptyPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new CreateFolderRequest(string.Empty));
+
+        result.ShouldHaveValidationErrorFor(r => r.Path)
+            .WithErrorMessage("Path is required.");
+    }
+
+    [Fact]
+    public void NullPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new CreateFolderRequest(null!));
+
+        result.ShouldHaveValidationErrorFor(r => r.Path)
+            .WithErrorMessage("Path is required.");
+    }
+
+    [Fact]
+    public void ValidPath_Passes()
+    {
+        var result = _validator.TestValidate(new CreateFolderRequest("a/b/c"));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.Path);
+    }
+
+    [Fact]
+    public void TraversalPath_FailsWith_DotDotMessage()
+    {
+        var result = _validator.TestValidate(new CreateFolderRequest("../etc/passwd"));
+
+        result.ShouldHaveValidationErrorFor(r => r.Path)
+            .WithErrorMessage("Path must not contain '..'.");
+    }
+
+    [Fact]
+    public void EmbeddedTraversal_AnywhereInPath_Fails()
+    {
+        // Defence-in-depth: traversal segments embedded after a legitimate prefix must still be
+        // rejected. StoragePath.Parse handles this in the handler, but the request-body validator
+        // is the front-door guard, so it MUST also reject mid-path traversal.
+        var result = _validator.TestValidate(new CreateFolderRequest("a/b/../etc"));
+
+        result.ShouldHaveValidationErrorFor(r => r.Path)
+            .WithErrorMessage("Path must not contain '..'.");
+    }
+
+    [Fact]
+    public void PathExceeding4096Chars_Fails()
+    {
+        var longPath = new string('a', 4097);
+
+        var result = _validator.TestValidate(new CreateFolderRequest(longPath));
+
+        result.ShouldHaveValidationErrorFor(r => r.Path);
+    }
+
+    [Fact]
+    public void PathAtMaximumLength_Passes()
+    {
+        var maxPath = new string('a', 4096);
+
+        var result = _validator.TestValidate(new CreateFolderRequest(maxPath));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.Path);
+    }
+
+    [Fact]
+    public void Validator_ProducesPropertyName_ForFilter_CamelCasing()
+    {
+        // The endpoint filter camel-cases ValidationFailure.PropertyName for the wire-level errors
+        // dictionary key. Pin that the validator emits the C# property name so the camel-casing
+        // step has a deterministic input.
+        var result = _validator.Validate(new CreateFolderRequest(string.Empty));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle();
+        result.Errors[0].PropertyName.Should().Be("Path");
+    }
+}

--- a/tests/Strg.Api.Tests/Validators/MoveFileRequestValidatorTests.cs
+++ b/tests/Strg.Api.Tests/Validators/MoveFileRequestValidatorTests.cs
@@ -1,0 +1,82 @@
+using FluentValidation.TestHelper;
+using Strg.Api.Endpoints;
+using Strg.Api.Validators;
+using Xunit;
+
+namespace Strg.Api.Tests.Validators;
+
+/// <summary>
+/// STRG-085 — unit tests for <see cref="MoveFileRequestValidator"/>. Mirrors the
+/// CreateFolderRequestValidatorTests shape since the rules are isomorphic — empty-path,
+/// length cap, traversal token. Per-test files are kept separate (not parameterized across
+/// validators) because the property name on each request type is distinct (<c>Path</c> vs
+/// <c>TargetPath</c>) and the wire-shape contract on the validator (PropertyName) is what the
+/// endpoint filter camel-cases into the RFC 7807 errors-dictionary key.
+/// </summary>
+public sealed class MoveFileRequestValidatorTests
+{
+    private readonly MoveFileRequestValidator _validator = new();
+
+    [Fact]
+    public void EmptyTargetPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new MoveFileRequest(string.Empty, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath is required.");
+    }
+
+    [Fact]
+    public void NullTargetPath_FailsWith_RequiredMessage()
+    {
+        var result = _validator.TestValidate(new MoveFileRequest(null!, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath is required.");
+    }
+
+    [Fact]
+    public void ValidTargetPath_Passes()
+    {
+        var result = _validator.TestValidate(new MoveFileRequest("a/b/c.txt", null));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetPath);
+    }
+
+    [Fact]
+    public void ValidTargetPath_WithCrossDriveId_Passes()
+    {
+        var result = _validator.TestValidate(new MoveFileRequest("a/b/c.txt", Guid.NewGuid()));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetPath);
+    }
+
+    [Fact]
+    public void TraversalTargetPath_Fails()
+    {
+        var result = _validator.TestValidate(new MoveFileRequest("../../etc/passwd", null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath)
+            .WithErrorMessage("TargetPath must not contain '..'.");
+    }
+
+    [Fact]
+    public void TargetPathExceeding4096Chars_Fails()
+    {
+        var longPath = new string('a', 4097);
+
+        var result = _validator.TestValidate(new MoveFileRequest(longPath, null));
+
+        result.ShouldHaveValidationErrorFor(r => r.TargetPath);
+    }
+
+    [Fact]
+    public void TargetPathAtMaximumLength_Passes()
+    {
+        var maxPath = new string('a', 4096);
+
+        var result = _validator.TestValidate(new MoveFileRequest(maxPath, null));
+
+        result.ShouldNotHaveValidationErrorFor(r => r.TargetPath);
+    }
+}

--- a/tests/Strg.Integration.Tests/Common/ValidationProblemDocument.cs
+++ b/tests/Strg.Integration.Tests/Common/ValidationProblemDocument.cs
@@ -19,7 +19,7 @@ internal sealed record ValidationProblemDocument
     public string? Title { get; init; }
 
     [JsonPropertyName("status")]
-    public int Status { get; init; }
+    public int? Status { get; init; }
 
     [JsonPropertyName("errors")]
     public Dictionary<string, string[]>? Errors { get; init; }

--- a/tests/Strg.Integration.Tests/Common/ValidationProblemDocument.cs
+++ b/tests/Strg.Integration.Tests/Common/ValidationProblemDocument.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace Strg.Integration.Tests.Common;
+
+/// <summary>
+/// STRG-085 — wire-shape of the RFC 7807 <c>ValidationProblemDetails</c> envelope emitted by
+/// <c>ValidationProblemDetailsFilter&lt;TRequest&gt;</c>. ASP.NET Core's
+/// <c>Results.ValidationProblem</c> serializes <c>type</c>, <c>title</c>, <c>status</c>, and an
+/// <c>errors</c> dictionary keyed by camel-cased property name. This record gives integration
+/// tests a strongly-typed view so they can assert per-property error messages without parsing
+/// raw JSON.
+/// </summary>
+internal sealed record ValidationProblemDocument
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("status")]
+    public int Status { get; init; }
+
+    [JsonPropertyName("errors")]
+    public Dictionary<string, string[]>? Errors { get; init; }
+}

--- a/tests/Strg.Integration.Tests/Copy/FileCopyTests.cs
+++ b/tests/Strg.Integration.Tests/Copy/FileCopyTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Strg.Core.Auditing;
 using Strg.Core.Constants;
 using Strg.Core.Domain;
+using Strg.Integration.Tests.Common;
 using Xunit;
 
 namespace Strg.Integration.Tests.Copy;
@@ -176,8 +177,14 @@ public sealed class FileCopyTests(FileCopyFixture fx) : IClassFixture<FileCopyFi
     }
 
     [Fact]
-    public async Task TC005_PathTraversal_Returns400_InvalidPath()
+    public async Task TC005_PathTraversal_Returns400_AsValidationProblemDetails()
     {
+        // STRG-085: traversal is now blocked at the request-body validator
+        // (CopyFileRequestValidator) BEFORE the handler runs, so the wire envelope is RFC 7807
+        // ValidationProblemDetails — not the legacy {code,message} shape that StoragePath.Parse
+        // would have produced inside the handler. The handler-side StoragePath.Parse check is
+        // retained as belt-and-suspenders for non-HTTP callers; this test pins the front-door
+        // contract that HTTP traversal attempts surface as the validation envelope.
         var folder = $"tc005-{Guid.NewGuid():N}";
         var sourceId = await fx.SeedFileAsync($"{folder}/source.txt");
 
@@ -189,8 +196,13 @@ public sealed class FileCopyTests(FileCopyFixture fx) : IClassFixture<FileCopyFi
             new { targetPath = "../../etc/passwd", targetDriveId = (Guid?)null });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var body = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
-        body!.Code.Should().Be("InvalidPath");
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Title.Should().Be("Validation failed");
+        problem.Status.Should().Be(400);
+        problem.Errors.Should().ContainKey("targetPath");
+        problem.Errors!["targetPath"].Should().ContainMatch("*'..'*");
     }
 
     [Fact]

--- a/tests/Strg.Integration.Tests/Copy/FileCopyTests.cs
+++ b/tests/Strg.Integration.Tests/Copy/FileCopyTests.cs
@@ -206,6 +206,31 @@ public sealed class FileCopyTests(FileCopyFixture fx) : IClassFixture<FileCopyFi
     }
 
     [Fact]
+    public async Task EmptyTargetPath_Returns400_AsValidationProblemDetails()
+    {
+        // Pins the NotEmpty rule on CopyFileRequestValidator at the wire level. Without this,
+        // a regression that drops the rule would still pass unit tests in isolation but ship
+        // a contract violation to clients. Folder has parity (TC001_EmptyPath_…); this is the
+        // copy-endpoint analogue.
+        var folder = $"empty-tp-{Guid.NewGuid():N}";
+        var sourceId = await fx.SeedFileAsync($"{folder}/source.txt");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{sourceId}/copy",
+            new { targetPath = "", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Errors.Should().ContainKey("targetPath");
+        problem.Errors!["targetPath"].Should().ContainMatch("*required*");
+    }
+
+    [Fact]
     public async Task TC006_CopyFile_FromWrongDrive_Returns404()
     {
         // Cross-drive id mismatch on SOURCE collapses to 404 (enumeration-oracle protection).

--- a/tests/Strg.Integration.Tests/Folders/FolderCreateTests.cs
+++ b/tests/Strg.Integration.Tests/Folders/FolderCreateTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Strg.Core.Auditing;
+using Strg.Integration.Tests.Common;
 using Xunit;
 
 namespace Strg.Integration.Tests.Folders;
@@ -130,8 +131,14 @@ public sealed class FolderCreateTests(FolderCreateFixture fx) : IClassFixture<Fo
     }
 
     [Fact]
-    public async Task TC004_PathTraversal_Returns400()
+    public async Task TC004_PathTraversal_Returns400_AsValidationProblemDetails()
     {
+        // STRG-085: traversal is now blocked at the request-body validator
+        // (CreateFolderRequestValidator) BEFORE the handler runs, so the wire envelope is RFC 7807
+        // ValidationProblemDetails — not the legacy {code,message} shape that StoragePath.Parse
+        // would have produced inside the handler. The handler-side StoragePath.Parse check is
+        // retained as belt-and-suspenders for non-HTTP callers; this test pins the front-door
+        // contract that HTTP traversal attempts surface as the validation envelope.
         var token = await fx.AuthenticateAsync();
         using var client = fx.CreateAuthenticatedClient(token);
 
@@ -141,9 +148,32 @@ public sealed class FolderCreateTests(FolderCreateFixture fx) : IClassFixture<Fo
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var body = await response.Content.ReadFromJsonAsync<FolderErrorDto>();
-        body.Should().NotBeNull();
-        body!.Code.Should().Be("InvalidPath", "AC: traversal must surface as the InvalidPath error code, not a generic 400");
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Title.Should().Be("Validation failed");
+        problem.Status.Should().Be(400);
+        problem.Errors.Should().ContainKey("path");
+        problem.Errors!["path"].Should().ContainMatch("*'..'*");
+    }
+
+    [Fact]
+    public async Task TC001_EmptyPath_Returns400_AsValidationProblemDetails()
+    {
+        // STRG-085 TC-001 — POST /folders with empty path is now caught by the request-body
+        // validator (NotEmpty rule on Path). The handler never runs.
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/folders",
+            new { path = "" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Errors.Should().ContainKey("path");
+        problem.Errors!["path"].Should().ContainMatch("*required*");
     }
 
     [Fact]

--- a/tests/Strg.Integration.Tests/Movement/FileMoveTests.cs
+++ b/tests/Strg.Integration.Tests/Movement/FileMoveTests.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Strg.Core.Auditing;
 using Strg.Core.Constants;
 using Strg.Core.Domain;
+using Strg.Integration.Tests.Common;
 using Xunit;
 
 namespace Strg.Integration.Tests.Movement;
@@ -116,8 +117,14 @@ public sealed class FileMoveTests(FileMoveFixture fx) : IClassFixture<FileMoveFi
     }
 
     [Fact]
-    public async Task TC004_PathTraversal_Returns400_InvalidPath()
+    public async Task TC004_PathTraversal_Returns400_AsValidationProblemDetails()
     {
+        // STRG-085: traversal is now blocked at the request-body validator
+        // (MoveFileRequestValidator) BEFORE the handler runs, so the wire envelope is RFC 7807
+        // ValidationProblemDetails — not the legacy {code,message} shape that StoragePath.Parse
+        // would have produced inside the handler. The handler-side StoragePath.Parse check is
+        // retained as belt-and-suspenders for non-HTTP callers; this test pins the front-door
+        // contract that HTTP traversal attempts surface as the validation envelope.
         var folder = $"tc004-{Guid.NewGuid():N}";
         var fileId = await fx.SeedFileAsync($"{folder}/source.txt");
 
@@ -130,9 +137,12 @@ public sealed class FileMoveTests(FileMoveFixture fx) : IClassFixture<FileMoveFi
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 
-        var body = await response.Content.ReadFromJsonAsync<ErrorResponseDto>();
-        body.Should().NotBeNull();
-        body!.Code.Should().Be("InvalidPath");
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Title.Should().Be("Validation failed");
+        problem.Status.Should().Be(400);
+        problem.Errors.Should().ContainKey("targetPath");
+        problem.Errors!["targetPath"].Should().ContainMatch("*'..'*");
     }
 
     [Fact]

--- a/tests/Strg.Integration.Tests/Movement/FileMoveTests.cs
+++ b/tests/Strg.Integration.Tests/Movement/FileMoveTests.cs
@@ -146,6 +146,31 @@ public sealed class FileMoveTests(FileMoveFixture fx) : IClassFixture<FileMoveFi
     }
 
     [Fact]
+    public async Task EmptyTargetPath_Returns400_AsValidationProblemDetails()
+    {
+        // Pins the NotEmpty rule on MoveFileRequestValidator at the wire level. Without this,
+        // a regression that drops the rule would still pass unit tests in isolation but ship
+        // a contract violation to clients. Folder has parity (TC001_EmptyPath_…); this is the
+        // move-endpoint analogue.
+        var folder = $"empty-tp-{Guid.NewGuid():N}";
+        var fileId = await fx.SeedFileAsync($"{folder}/source.txt");
+
+        var token = await fx.AuthenticateAsync();
+        using var client = fx.CreateAuthenticatedClient(token);
+
+        var response = await client.PostAsJsonAsync(
+            $"/api/v1/drives/{fx.DriveId}/files/{fileId}/move",
+            new { targetPath = "", targetDriveId = (Guid?)null });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        var problem = await response.Content.ReadFromJsonAsync<ValidationProblemDocument>();
+        problem.Should().NotBeNull();
+        problem!.Errors.Should().ContainKey("targetPath");
+        problem.Errors!["targetPath"].Should().ContainMatch("*required*");
+    }
+
+    [Fact]
     public async Task TC005_DirectoryMove_WithinDrive_Returns200_RootAndDescendantsRewritten()
     {
         // Phase 2 — flipped from rejection-pin to happy-path. Single descendant; the N-descendant


### PR DESCRIPTION
Wires per-endpoint FluentValidation against CreateFolderRequest, MoveFileRequest, and
CopyFileRequest via a generic ValidationProblemDetailsFilter<TRequest> that surfaces
failures as RFC 7807 ValidationProblemDetails. Path traversal (..), empty values, and
oversize bodies are now rejected at the front door before the handler runs;
StoragePath.Parse remains in the handler as belt-and-suspenders for non-HTTP callers.

AddFluentValidationAutoValidation is registered for forward MVC compatibility but the
load-bearing surface is the per-route filter, since the API is minimal-API only.