### PR TITLE
feat(drives): STRG-300 — per-user default-drive selection (UserDriveDefault) + auto-default first drive

### DIFF
--- a/src/Strg.Application/Abstractions/IStrgDbContext.cs
+++ b/src/Strg.Application/Abstractions/IStrgDbContext.cs
@@ -24,6 +24,7 @@ public interface IStrgDbContext
     DbSet<InboxRule> InboxRules { get; }
     DbSet<FileLock> FileLocks { get; }
     DbSet<PendingUpload> PendingUploads { get; }
+    DbSet<UserDriveDefault> UserDriveDefaults { get; }
 
     DatabaseFacade Database { get; }
 

--- a/src/Strg.Application/Features/Drives/Create/CreateDriveHandler.cs
+++ b/src/Strg.Application/Features/Drives/Create/CreateDriveHandler.cs
@@ -41,6 +41,25 @@ internal sealed class CreateDriveHandler(
             return Result<Drive>.Failure("DuplicateName", $"Drive '{command.Name}' already exists.");
         }
 
+        // First non-soft-deleted drive in the tenant becomes the tenant-wide default. The
+        // AnyAsync probe runs through both the tenant filter (scopes to current tenant) and the
+        // soft-delete filter (hides DeletedAt-set rows), so a tenant that soft-deleted all of its
+        // drives "restarts" — the next create is treated as a first drive again. An admin who
+        // wants explicit control passes IsDefault=true|false on the command and bypasses the
+        // heuristic entirely.
+        bool isDefault;
+        if (command.IsDefault.HasValue)
+        {
+            isDefault = command.IsDefault.Value;
+        }
+        else
+        {
+            var tenantHasAnyDrive = await db.Drives
+                .AnyAsync(_ => true, cancellationToken)
+                .ConfigureAwait(false);
+            isDefault = !tenantHasAnyDrive;
+        }
+
         var drive = new Drive
         {
             TenantId = tenantId,
@@ -48,7 +67,7 @@ internal sealed class CreateDriveHandler(
             ProviderType = command.ProviderType,
             ProviderConfig = command.ProviderConfigJson ?? "{}",
             EncryptionEnabled = command.EncryptionEnabled,
-            IsDefault = command.IsDefault ?? false,
+            IsDefault = isDefault,
         };
 
         db.Drives.Add(drive);

--- a/src/Strg.Application/Features/Drives/GetDefault/GetDefaultDriveHandler.cs
+++ b/src/Strg.Application/Features/Drives/GetDefault/GetDefaultDriveHandler.cs
@@ -1,0 +1,40 @@
+using Mediator;
+using Microsoft.EntityFrameworkCore;
+using Strg.Application.Abstractions;
+using Strg.Core.Domain;
+
+namespace Strg.Application.Features.Drives.GetDefault;
+
+internal sealed class GetDefaultDriveHandler(
+    IStrgDbContext db,
+    ICurrentUser currentUser)
+    : IQueryHandler<GetDefaultDriveQuery, Drive?>
+{
+    public async ValueTask<Drive?> Handle(GetDefaultDriveQuery query, CancellationToken cancellationToken)
+    {
+        var userId = currentUser.UserId;
+
+        // Step 1: per-user override (UserDriveDefault tenant filter scopes to current tenant).
+        var preference = await db.UserDriveDefaults
+            .FirstOrDefaultAsync(d => d.UserId == userId, cancellationToken)
+            .ConfigureAwait(false);
+        if (preference is not null)
+        {
+            // Soft-deleted drive ⇒ filter hides it ⇒ falls through to the tenant default. Stale
+            // UserDriveDefault rows are intentionally not garbage-collected here; cleanup is
+            // tracked as a follow-up if it becomes a real problem.
+            var picked = await db.Drives
+                .FirstOrDefaultAsync(d => d.Id == preference.DriveId, cancellationToken)
+                .ConfigureAwait(false);
+            if (picked is not null)
+            {
+                return picked;
+            }
+        }
+
+        // Step 2: tenant-wide bootstrap default.
+        return await db.Drives
+            .FirstOrDefaultAsync(d => d.IsDefault, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/Strg.Application/Features/Drives/GetDefault/GetDefaultDriveQuery.cs
+++ b/src/Strg.Application/Features/Drives/GetDefault/GetDefaultDriveQuery.cs
@@ -1,0 +1,12 @@
+using Mediator;
+using Strg.Core.Domain;
+
+namespace Strg.Application.Features.Drives.GetDefault;
+
+/// <summary>
+/// Returns the calling user's effective default drive: the drive referenced by their
+/// <see cref="UserDriveDefault"/> row when one exists, otherwise the tenant's
+/// <see cref="Drive.IsDefault"/> drive, otherwise <see langword="null"/>. Null-return is the
+/// documented contract — callers (the inbox feature) decide what to do when no default exists.
+/// </summary>
+public sealed record GetDefaultDriveQuery() : IQuery<Drive?>;

--- a/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveCommand.cs
+++ b/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveCommand.cs
@@ -1,0 +1,16 @@
+using Mediator;
+using Strg.Application.Abstractions;
+using Strg.Core;
+using Strg.Core.Domain;
+
+namespace Strg.Application.Features.Drives.SetDefault;
+
+/// <summary>
+/// Sets the calling user's per-user default drive within the current tenant. Upserts the
+/// (TenantId, UserId) row in <see cref="UserDriveDefault"/>; never mutates
+/// <see cref="Drive.IsDefault"/> (that flag is the tenant-wide bootstrap default and is
+/// owned by Create / Update). Cross-tenant <c>DriveId</c> lookups throw
+/// <see cref="Strg.Core.Exceptions.NotFoundException"/>.
+/// </summary>
+public sealed record SetDefaultDriveCommand(Guid DriveId)
+    : ICommand<Result<Drive>>, ITenantScopedCommand, IAuditedCommand;

--- a/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveHandler.cs
+++ b/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveHandler.cs
@@ -1,0 +1,75 @@
+using Mediator;
+using Microsoft.EntityFrameworkCore;
+using Strg.Application.Abstractions;
+using Strg.Application.Auditing;
+using Strg.Core;
+using Strg.Core.Auditing;
+using Strg.Core.Domain;
+using Strg.Core.Exceptions;
+
+namespace Strg.Application.Features.Drives.SetDefault;
+
+internal sealed class SetDefaultDriveHandler(
+    IStrgDbContext db,
+    ITenantContext tenantContext,
+    ICurrentUser currentUser,
+    IAuditScope auditScope)
+    : ICommandHandler<SetDefaultDriveCommand, Result<Drive>>
+{
+    public async ValueTask<Result<Drive>> Handle(SetDefaultDriveCommand command, CancellationToken cancellationToken)
+    {
+        // Tenant filter on db.Drives ensures cross-tenant ids return null. Throwing NotFound
+        // (rather than Result.Failure) matches CLAUDE.md's exception-error-mode rule: cross-tenant
+        // access attempts are exceptional, not part of the wire contract. StrgErrorFilter maps it
+        // to NOT_FOUND on the GraphQL surface.
+        var drive = await db.Drives
+            .FirstOrDefaultAsync(d => d.Id == command.DriveId, cancellationToken)
+            .ConfigureAwait(false);
+        if (drive is null)
+        {
+            throw new NotFoundException($"Drive '{command.DriveId}' not found.");
+        }
+
+        var tenantId = tenantContext.TenantId;
+        var userId = currentUser.UserId;
+
+        var existing = await db.UserDriveDefaults
+            .FirstOrDefaultAsync(d => d.UserId == userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        Guid? previousDriveId = existing?.DriveId;
+        if (existing is null)
+        {
+            db.UserDriveDefaults.Add(new UserDriveDefault
+            {
+                TenantId = tenantId,
+                UserId = userId,
+                DriveId = drive.Id,
+            });
+        }
+        else if (existing.DriveId != drive.Id)
+        {
+            existing.DriveId = drive.Id;
+        }
+        else
+        {
+            // No-op: user is "setting" the same drive they already have. Skip SaveChanges and
+            // audit so the audit log reflects state changes only, mirroring UpdateDriveHandler.
+            return Result<Drive>.Success(drive);
+        }
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        var details = previousDriveId.HasValue
+            ? $"previous={previousDriveId.Value}"
+            : "previous=none";
+        auditScope.Record(
+            AuditActions.DriveDefaultChanged,
+            AuditResourceTypes.Drive,
+            drive.Id,
+            details: details,
+            userId: userId);
+
+        return Result<Drive>.Success(drive);
+    }
+}

--- a/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveValidator.cs
+++ b/src/Strg.Application/Features/Drives/SetDefault/SetDefaultDriveValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace Strg.Application.Features.Drives.SetDefault;
+
+public sealed class SetDefaultDriveValidator : AbstractValidator<SetDefaultDriveCommand>
+{
+    public SetDefaultDriveValidator()
+    {
+        RuleFor(c => c.DriveId).NotEmpty();
+    }
+}

--- a/src/Strg.Core/Auditing/AuditActions.cs
+++ b/src/Strg.Core/Auditing/AuditActions.cs
@@ -138,4 +138,14 @@ public static class AuditActions
     /// <c>"FileItem"</c>, ResourceId is the folder id, Details carries <c>driveId=...; path=...</c>.
     /// </summary>
     public const string FolderCreated = "folder.created";
+
+    /// <summary>
+    /// A user picked (or changed) their per-user default drive within a tenant. ResourceType is
+    /// <c>"Drive"</c>, ResourceId is the newly-selected drive id, Details carries the previous
+    /// drive id when one existed (<c>previous=&lt;guid&gt;</c>) or <c>previous=none</c> on the first
+    /// pick. Distinct from <see cref="DriveUpdated"/>, which records mutations to the tenant-wide
+    /// <c>Drive.IsDefault</c> flag — this action records mutations to the per-user override
+    /// stored in <c>UserDriveDefault</c>.
+    /// </summary>
+    public const string DriveDefaultChanged = "drive.default_changed";
 }

--- a/src/Strg.Core/Domain/UserDriveDefault.cs
+++ b/src/Strg.Core/Domain/UserDriveDefault.cs
@@ -1,0 +1,12 @@
+namespace Strg.Core.Domain;
+
+/// <summary>
+/// Per-user override of which drive a user considers "default" within a tenant. At most one row
+/// per (TenantId, UserId). Falls back to the tenant-wide <see cref="Drive.IsDefault"/> drive when
+/// no row exists. Read by GetDefaultDriveQuery; written by SetDefaultDriveCommand (upsert).
+/// </summary>
+public sealed class UserDriveDefault : TenantedEntity
+{
+    public Guid UserId { get; init; }
+    public Guid DriveId { get; set; }
+}

--- a/src/Strg.GraphQl/Inputs/Drive/SetDefaultDriveInput.cs
+++ b/src/Strg.GraphQl/Inputs/Drive/SetDefaultDriveInput.cs
@@ -1,0 +1,3 @@
+namespace Strg.GraphQl.Inputs.Drive;
+
+public sealed record SetDefaultDriveInput(Guid DriveId);

--- a/src/Strg.GraphQl/Mutations/Storage/DriveMutations.cs
+++ b/src/Strg.GraphQl/Mutations/Storage/DriveMutations.cs
@@ -2,6 +2,7 @@ using HotChocolate.Authorization;
 using Mediator;
 using Strg.Application.Features.Drives.Create;
 using Strg.Application.Features.Drives.Delete;
+using Strg.Application.Features.Drives.SetDefault;
 using Strg.Application.Features.Drives.Update;
 using Strg.GraphQl.Inputs.Drive;
 using Strg.GraphQl.Payloads;
@@ -45,6 +46,23 @@ public sealed class DriveMutations
         return result.IsSuccess
             ? new UpdateDrivePayload(result.Value, null)
             : new UpdateDrivePayload(null, [new UserError(MapCode(result.ErrorCode!), result.ErrorMessage!, FieldFor(result))]);
+    }
+
+    // Picking the calling user's per-user default is a user-level action, NOT admin-only.
+    // Cross-tenant DriveId lookups throw NotFoundException in the handler, which the global
+    // StrgErrorFilter maps to a top-level NOT_FOUND error — distinct from validation failures
+    // which surface in the payload's errors[] field.
+    [Authorize]
+    public async Task<SetDefaultDrivePayload> SetDefaultDriveAsync(
+        SetDefaultDriveInput input,
+        [Service] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new SetDefaultDriveCommand(input.DriveId), cancellationToken);
+
+        return result.IsSuccess
+            ? new SetDefaultDrivePayload(result.Value, null)
+            : new SetDefaultDrivePayload(null, [new UserError(MapCode(result.ErrorCode!), result.ErrorMessage!, FieldFor(result))]);
     }
 
     [Authorize(Policy = "Admin")]

--- a/src/Strg.GraphQl/Payloads/Drive/SetDefaultDrivePayload.cs
+++ b/src/Strg.GraphQl/Payloads/Drive/SetDefaultDrivePayload.cs
@@ -1,0 +1,3 @@
+namespace Strg.GraphQl.Payloads.Drive;
+
+public sealed record SetDefaultDrivePayload(Core.Domain.Drive? Drive, IReadOnlyList<UserError>? Errors);

--- a/src/Strg.Infrastructure/Data/Configurations/UserDriveDefaultConfiguration.cs
+++ b/src/Strg.Infrastructure/Data/Configurations/UserDriveDefaultConfiguration.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Strg.Core.Domain;
+
+namespace Strg.Infrastructure.Data.Configurations;
+
+public sealed class UserDriveDefaultConfiguration : IEntityTypeConfiguration<UserDriveDefault>
+{
+    public void Configure(EntityTypeBuilder<UserDriveDefault> builder)
+    {
+        builder.HasKey(d => d.Id);
+        // Unique per (TenantId, UserId): a user has at most one default drive per tenant. The
+        // global tenant filter handles cross-tenant reads; this index is the DB-level backstop
+        // against duplicate-row races. SetDefaultDriveHandler upserts on this exact key tuple.
+        builder.HasIndex(d => new { d.TenantId, d.UserId }).IsUnique();
+        builder.HasIndex(d => d.DriveId);
+        builder.Ignore(d => d.IsDeleted);
+    }
+}

--- a/src/Strg.Infrastructure/Data/Migrations/20260501100000_AddDriveIsDefault.Designer.cs
+++ b/src/Strg.Infrastructure/Data/Migrations/20260501100000_AddDriveIsDefault.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Strg.Infrastructure.Data;
@@ -11,9 +12,11 @@ using Strg.Infrastructure.Data;
 namespace Strg.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(StrgDbContext))]
-    partial class StrgDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501100000_AddDriveIsDefault")]
+    partial class AddDriveIsDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1011,40 +1014,6 @@ namespace Strg.Infrastructure.Data.Migrations
                         .IsUnique();
 
                     b.ToTable("Users");
-                });
-
-            modelBuilder.Entity("Strg.Core.Domain.UserDriveDefault", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTimeOffset?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("DriveId")
-                        .HasColumnType("uuid");
-
-                    b.Property<Guid>("TenantId")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DriveId");
-
-                    b.HasIndex("TenantId", "UserId")
-                        .IsUnique();
-
-                    b.ToTable("UserDriveDefaults");
                 });
 
             modelBuilder.Entity("MassTransit.EntityFrameworkCoreIntegration.OutboxMessage", b =>

--- a/src/Strg.Infrastructure/Data/Migrations/20260501100000_AddDriveIsDefault.cs
+++ b/src/Strg.Infrastructure/Data/Migrations/20260501100000_AddDriveIsDefault.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Strg.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDriveIsDefault : Migration
+    {
+        // Intentionally empty. The Drives.IsDefault column was created by the original
+        // 20260421214650_InitialCreate migration; this placeholder migration exists solely to
+        // satisfy the STRG-300 acceptance-criterion line item that names a migration called
+        // AddDriveIsDefault. The companion 20260501100001_AddUserDriveDefault migration carries
+        // the real schema change for the per-user-default feature.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/src/Strg.Infrastructure/Data/Migrations/20260501100001_AddUserDriveDefault.Designer.cs
+++ b/src/Strg.Infrastructure/Data/Migrations/20260501100001_AddUserDriveDefault.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Strg.Infrastructure.Data;
@@ -11,9 +12,11 @@ using Strg.Infrastructure.Data;
 namespace Strg.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(StrgDbContext))]
-    partial class StrgDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501100001_AddUserDriveDefault")]
+    partial class AddUserDriveDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Strg.Infrastructure/Data/Migrations/20260501100001_AddUserDriveDefault.cs
+++ b/src/Strg.Infrastructure/Data/Migrations/20260501100001_AddUserDriveDefault.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Strg.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserDriveDefault : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserDriveDefaults",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DriveId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserDriveDefaults", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDriveDefaults_DriveId",
+                table: "UserDriveDefaults",
+                column: "DriveId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserDriveDefaults_TenantId_UserId",
+                table: "UserDriveDefaults",
+                columns: new[] { "TenantId", "UserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserDriveDefaults");
+        }
+    }
+}

--- a/src/Strg.Infrastructure/Data/StrgDbContext.cs
+++ b/src/Strg.Infrastructure/Data/StrgDbContext.cs
@@ -35,6 +35,7 @@ public class StrgDbContext(
     public DbSet<InboxRule> InboxRules => Set<InboxRule>();
     public DbSet<FileLock> FileLocks => Set<FileLock>();
     public DbSet<PendingUpload> PendingUploads => Set<PendingUpload>();
+    public DbSet<UserDriveDefault> UserDriveDefaults => Set<UserDriveDefault>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/tests/Strg.GraphQl.Tests/Mutations/DriveMutationsTests.cs
+++ b/tests/Strg.GraphQl.Tests/Mutations/DriveMutationsTests.cs
@@ -127,4 +127,123 @@ public class DriveMutationsTests
         Assert.Equal(JsonValueKind.Object, driveEl.ValueKind);
         Assert.Equal("my-drive", driveEl.GetProperty("name").GetString());
     }
+
+    /// <summary>
+    /// STRG-300 — verifies the <c>setDefaultDrive</c> mutation surfaces the picked drive in the
+    /// payload and returns no errors on the happy path. Drives the wire contract end-to-end:
+    /// input shape, payload shape, auth (the [Authorize] attribute is satisfied by
+    /// AllowAllAuthorizationHandler), and the new <c>isDefault</c> field exposure.
+    /// </summary>
+    [Fact]
+    public async Task SetDefaultDrive_ValidDriveId_ReturnsDrive()
+    {
+        var tenantId = Guid.NewGuid();
+        SharedTenantCtx.TenantId = tenantId;
+        var dbName = Guid.NewGuid().ToString();
+
+        var executor = await CreateExecutorAsync(tenantId, dbName);
+
+        // Seed a drive via the same in-memory DB the mutation reads from.
+        var driveId = Guid.NewGuid();
+        await using (var scope = executor.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<StrgDbContext>();
+            db.Drives.Add(new Drive
+            {
+                Id = driveId,
+                TenantId = tenantId,
+                Name = "the-drive",
+                ProviderType = "local",
+                ProviderConfig = "{}",
+                EncryptionEnabled = false,
+                IsDefault = true,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var result = (IOperationResult)await executor.ExecuteAsync($$"""
+            mutation {
+              storage {
+                setDefaultDrive(input: { driveId: "{{driveId}}" }) {
+                  drive { id name isDefault }
+                  errors { code }
+                }
+              }
+            }
+            """);
+
+        var json = result.ToJson();
+        using var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("data", out var data), $"no data: {json}");
+        var setDefaultEl = data.GetProperty("storage").GetProperty("setDefaultDrive");
+        var driveEl = setDefaultEl.GetProperty("drive");
+        Assert.Equal(JsonValueKind.Object, driveEl.ValueKind);
+        Assert.Equal("the-drive", driveEl.GetProperty("name").GetString());
+        Assert.True(driveEl.GetProperty("isDefault").GetBoolean(), "the GraphQL DriveType must expose isDefault");
+
+        var errorsEl = setDefaultEl.GetProperty("errors");
+        Assert.True(errorsEl.ValueKind == JsonValueKind.Null || !errorsEl.EnumerateArray().Any(),
+            $"happy path must return no errors; got {errorsEl}");
+    }
+
+    /// <summary>
+    /// STRG-300 TC-005 — cross-tenant DriveId. The handler throws <c>NotFoundException</c>
+    /// (mapped by <c>StrgErrorFilter</c> to the top-level <c>NOT_FOUND</c> error rather than to
+    /// the payload's <c>errors[]</c>). Pins the global tenant filter at the GraphQL surface.
+    /// </summary>
+    [Fact]
+    public async Task SetDefaultDrive_CrossTenantDriveId_ReturnsNotFoundError()
+    {
+        var tenantId = Guid.NewGuid();
+        var foreignTenantId = Guid.NewGuid();
+        SharedTenantCtx.TenantId = tenantId;
+        var dbName = Guid.NewGuid().ToString();
+
+        var executor = await CreateExecutorAsync(tenantId, dbName);
+
+        // Seed a drive that belongs to a foreign tenant. The current tenant's filter must hide it.
+        var foreignDriveId = Guid.NewGuid();
+        await using (var scope = executor.Services.CreateAsyncScope())
+        {
+            // Switch the shared context to the foreign tenant for the seed insert, then flip back.
+            SharedTenantCtx.TenantId = foreignTenantId;
+            try
+            {
+                var db = scope.ServiceProvider.GetRequiredService<StrgDbContext>();
+                db.Drives.Add(new Drive
+                {
+                    Id = foreignDriveId,
+                    TenantId = foreignTenantId,
+                    Name = "foreign-drive",
+                    ProviderType = "local",
+                    ProviderConfig = "{}",
+                    EncryptionEnabled = false,
+                });
+                await db.SaveChangesAsync();
+            }
+            finally
+            {
+                SharedTenantCtx.TenantId = tenantId;
+            }
+        }
+
+        var result = (IOperationResult)await executor.ExecuteAsync($$"""
+            mutation {
+              storage {
+                setDefaultDrive(input: { driveId: "{{foreignDriveId}}" }) {
+                  drive { id }
+                  errors { code }
+                }
+              }
+            }
+            """);
+
+        var json = result.ToJson();
+        using var doc = JsonDocument.Parse(json);
+        // NotFoundException surfaces as a top-level GraphQL error (NOT in the payload's errors[]).
+        Assert.True(doc.RootElement.TryGetProperty("errors", out var errorsEl), $"expected top-level errors: {json}");
+        var topErrors = errorsEl.EnumerateArray().ToList();
+        Assert.NotEmpty(topErrors);
+        Assert.Equal("NOT_FOUND", topErrors[0].GetProperty("extensions").GetProperty("code").GetString());
+    }
 }

--- a/tests/Strg.GraphQl.Tests/SchemaTests.cs
+++ b/tests/Strg.GraphQl.Tests/SchemaTests.cs
@@ -30,6 +30,29 @@ public class SchemaTests
         Assert.DoesNotContain("tenantId", fields);
     }
 
+    /// <summary>
+    /// STRG-300 — pins that the new <c>isDefault</c> field is exposed on the GraphQL Drive type.
+    /// A future change that adds <c>.Ignore()</c> to <c>DriveType</c> would silently hide it from
+    /// the wire and break the inbox-feature consumer; this test catches that regression.
+    /// </summary>
+    [Fact]
+    public async Task DriveType_IsDefault_InSchema()
+    {
+        var executor = await GraphQlTestFixture.CreateExecutorAsync(
+            configureSchema: b => b.AddType<GraphQLDriveType>());
+
+        var result = (IOperationResult)await executor.ExecuteAsync("""
+            {
+              __type(name: "Drive") {
+                fields { name }
+              }
+            }
+            """);
+
+        var fields = GetFieldNames(result, "__type");
+        Assert.Contains("isDefault", fields);
+    }
+
     [Fact]
     public async Task FileItemType_HasIsFolder_NotIsDirectory()
     {

--- a/tests/Strg.Integration.Tests/Application/Drives/DriveDefaultHandlerTests.cs
+++ b/tests/Strg.Integration.Tests/Application/Drives/DriveDefaultHandlerTests.cs
@@ -1,0 +1,324 @@
+using FluentAssertions;
+using Mediator;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Strg.Application.Abstractions;
+using Strg.Application.DependencyInjection;
+using Strg.Application.Features.Drives.Create;
+using Strg.Application.Features.Drives.GetDefault;
+using Strg.Application.Features.Drives.SetDefault;
+using Strg.Core.Auditing;
+using Strg.Core.Domain;
+using Strg.Core.Exceptions;
+using Strg.Core.Storage;
+using Strg.Infrastructure.Auditing;
+using Strg.Infrastructure.Data;
+using Strg.Infrastructure.Storage;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace Strg.Integration.Tests.Application.Drives;
+
+internal sealed class FixedTenantContext(Guid id) : ITenantContext
+{
+    public Guid TenantId => id;
+}
+
+internal sealed class MutableCurrentUser : ICurrentUser
+{
+    public Guid UserId { get; set; }
+}
+
+/// <summary>
+/// STRG-300 integration tests for the per-user default drive feature. Each TC-* method pins one
+/// row of the issue's Test Cases section. Mediator is built the same way <c>TagHandlerTests</c>
+/// does — Testcontainers Postgres, real EF, real query filters — so a refactor that disables
+/// the tenant filter for <c>UserDriveDefault</c> or <c>Drive</c> trips the cross-tenant test.
+/// </summary>
+public sealed class DriveDefaultHandlerTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:17-alpine").Build();
+
+    public Task InitializeAsync() => _postgres.StartAsync();
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+
+    // TC-001
+    [Fact]
+    public async Task CreateDrive_first_drive_in_tenant_is_marked_default_automatically()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var result = await mediator.Send(new CreateDriveCommand("first", "local"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.IsDefault.Should().BeTrue("the first drive in a tenant becomes the bootstrap default");
+    }
+
+    // TC-002
+    [Fact]
+    public async Task CreateDrive_second_drive_does_not_steal_default_from_first()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var first = await mediator.Send(new CreateDriveCommand("first", "local"));
+        var second = await mediator.Send(new CreateDriveCommand("second", "local"));
+
+        first.Value!.IsDefault.Should().BeTrue();
+        second.Value!.IsDefault.Should().BeFalse("only the first drive auto-defaults; subsequent creates start non-default");
+
+        // Re-read first from DB to confirm the persisted state still has it as default.
+        await using var db = fx.NewDbContext();
+        var firstFromDb = await db.Drives.FirstAsync(d => d.Id == first.Value.Id);
+        firstFromDb.IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CreateDrive_explicit_isDefault_true_overrides_first_drive_heuristic()
+    {
+        // Admin override path: when IsDefault is passed explicitly, the auto-default heuristic
+        // is bypassed in both directions. Prevents a future change to the heuristic from
+        // silently flipping the admin-supplied value.
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var explicitFalse = await mediator.Send(new CreateDriveCommand("first", "local", IsDefault: false));
+        explicitFalse.Value!.IsDefault.Should().BeFalse(
+            "explicit false on the first drive must NOT be auto-flipped to true");
+    }
+
+    // TC-003
+    [Fact]
+    public async Task SetDefaultDrive_creates_user_drive_default_row_and_updates_on_re_invoke()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var first = await mediator.Send(new CreateDriveCommand("first", "local"));
+        var second = await mediator.Send(new CreateDriveCommand("second", "local"));
+
+        var pickFirst = await mediator.Send(new SetDefaultDriveCommand(first.Value!.Id));
+        pickFirst.IsSuccess.Should().BeTrue();
+        pickFirst.Value!.Id.Should().Be(first.Value.Id);
+
+        await using (var db = fx.NewDbContext())
+        {
+            var rows = await db.UserDriveDefaults.Where(u => u.UserId == user.Id).ToListAsync();
+            rows.Should().HaveCount(1);
+            rows[0].DriveId.Should().Be(first.Value.Id);
+        }
+
+        // Switch to the second drive — must reuse the same row, never create a duplicate.
+        var pickSecond = await mediator.Send(new SetDefaultDriveCommand(second.Value!.Id));
+        pickSecond.IsSuccess.Should().BeTrue();
+
+        await using (var db = fx.NewDbContext())
+        {
+            var rows = await db.UserDriveDefaults.Where(u => u.UserId == user.Id).ToListAsync();
+            rows.Should().HaveCount(1, "upsert must reuse the existing (TenantId, UserId) row");
+            rows[0].DriveId.Should().Be(second.Value.Id);
+        }
+    }
+
+    [Fact]
+    public async Task SetDefaultDrive_same_drive_twice_is_a_noop_and_does_not_double_audit()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var first = await mediator.Send(new CreateDriveCommand("first", "local"));
+
+        await mediator.Send(new SetDefaultDriveCommand(first.Value!.Id));
+        await mediator.Send(new SetDefaultDriveCommand(first.Value.Id));
+
+        var audits = await fx.LoadAuditEntriesAsync(AuditActions.DriveDefaultChanged);
+        audits.Should().HaveCount(1, "second invocation with same drive id is a no-op; no second audit row");
+    }
+
+    // TC-004
+    [Fact]
+    public async Task GetDefaultDrive_returns_null_when_tenant_has_no_drives()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var result = await mediator.Send(new GetDefaultDriveQuery());
+
+        result.Should().BeNull("no drives, no user preference — fallback chain produces null");
+    }
+
+    [Fact]
+    public async Task GetDefaultDrive_falls_back_to_tenant_default_when_user_has_no_preference()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        var first = await mediator.Send(new CreateDriveCommand("first", "local"));
+
+        var result = await mediator.Send(new GetDefaultDriveQuery());
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(first.Value!.Id, "tenant default is the fallback when no UserDriveDefault row exists");
+    }
+
+    [Fact]
+    public async Task GetDefaultDrive_returns_user_preference_when_set()
+    {
+        var fx = await CreateFixtureAsync();
+        var user = await fx.CreateUserAsync();
+        var mediator = fx.BuildMediator(user.Id);
+
+        // First drive is auto-tenant-default; user picks the SECOND drive as their personal default.
+        var first = await mediator.Send(new CreateDriveCommand("first", "local"));
+        var second = await mediator.Send(new CreateDriveCommand("second", "local"));
+        await mediator.Send(new SetDefaultDriveCommand(second.Value!.Id));
+
+        var result = await mediator.Send(new GetDefaultDriveQuery());
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(second.Value.Id, "user preference takes precedence over tenant default");
+        first.Value!.IsDefault.Should().BeTrue("tenant default flag is unchanged by per-user preference selection");
+    }
+
+    // TC-005
+    [Fact]
+    public async Task SetDefaultDrive_cross_tenant_drive_id_throws_NotFound()
+    {
+        var fxA = await CreateFixtureAsync();
+        var userA = await fxA.CreateUserAsync();
+        var mediatorA = fxA.BuildMediator(userA.Id);
+
+        var driveA = await mediatorA.Send(new CreateDriveCommand("first", "local"));
+
+        // Tenant B tries to set tenant A's drive as their default. The global tenant filter
+        // hides driveA from B's query, so the handler observes "drive not found" and throws
+        // NotFoundException — which the GraphQL error filter renders as NOT_FOUND.
+        var fxB = await fxA.WithNewTenantAsync();
+        var userB = await fxB.CreateUserAsync();
+        var mediatorB = fxB.BuildMediator(userB.Id);
+
+        var act = async () => await mediatorB.Send(new SetDefaultDriveCommand(driveA.Value!.Id));
+
+        await act.Should().ThrowAsync<NotFoundException>();
+
+        // Belt-and-braces: confirm no UserDriveDefault row was created under either tenant for
+        // tenant A's drive id.
+        await using var db = fxA.NewDbContext();
+        var leakedRows = await db.UserDriveDefaults
+            .IgnoreQueryFilters()
+            .Where(u => u.DriveId == driveA.Value.Id)
+            .ToListAsync();
+        leakedRows.Should().BeEmpty("a NotFound throw must abort the SaveChanges before any row hits the DB");
+    }
+
+    // ── fixture helpers ────────────────────────────────────────────────────────
+
+    private async Task<Fixture> CreateFixtureAsync()
+    {
+        var dbName = $"strg_test_{Guid.NewGuid():N}";
+        var adminConnectionString = _postgres.GetConnectionString();
+
+        await using (var connection = new NpgsqlConnection(adminConnectionString))
+        {
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"CREATE DATABASE \"{dbName}\"";
+            await command.ExecuteNonQueryAsync();
+        }
+
+        var testDbConnectionString = new NpgsqlConnectionStringBuilder(adminConnectionString)
+        {
+            Database = dbName,
+        }.ConnectionString;
+
+        var tenantId = Guid.NewGuid();
+        var tenantContext = new FixedTenantContext(tenantId);
+
+        var options = new DbContextOptionsBuilder<StrgDbContext>()
+            .UseNpgsql(testDbConnectionString)
+            .Options;
+
+        await using (var bootstrap = new StrgDbContext(options, tenantContext, new MutableCurrentUser { UserId = Guid.Empty }))
+        {
+            await bootstrap.Database.EnsureCreatedAsync();
+            bootstrap.Tenants.Add(new Tenant { Id = tenantId, Name = $"test-{tenantId:N}" });
+            await bootstrap.SaveChangesAsync();
+        }
+
+        return new Fixture(testDbConnectionString, tenantContext, tenantId);
+    }
+
+    private sealed class Fixture(
+        string connectionString,
+        ITenantContext tenantContext,
+        Guid tenantId)
+    {
+        public Guid TenantId { get; } = tenantId;
+
+        public StrgDbContext NewDbContext() => new(
+            new DbContextOptionsBuilder<StrgDbContext>().UseNpgsql(connectionString).Options,
+            tenantContext,
+            new MutableCurrentUser { UserId = Guid.Empty });
+
+        public IMediator BuildMediator(Guid currentUserId)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton(tenantContext);
+            services.AddSingleton<ICurrentUser>(new MutableCurrentUser { UserId = currentUserId });
+            services.AddDbContext<StrgDbContext>(o => o.UseNpgsql(connectionString));
+            services.AddScoped<IStrgDbContext>(sp => sp.GetRequiredService<StrgDbContext>());
+            services.AddScoped<IAuditService, AuditService>();
+            services.AddStrgStorageProviders();
+            services.AddStrgApplication();
+
+            return services.BuildServiceProvider().GetRequiredService<IMediator>();
+        }
+
+        public async Task<User> CreateUserAsync()
+        {
+            await using var ctx = NewDbContext();
+            var user = new User
+            {
+                TenantId = TenantId,
+                Email = $"drive-{Guid.NewGuid():N}@example.com",
+                DisplayName = "Drive Test",
+                PasswordHash = "not-a-real-hash-tests-only",
+                QuotaBytes = 1_000_000,
+            };
+            ctx.Users.Add(user);
+            await ctx.SaveChangesAsync();
+            return user;
+        }
+
+        public async Task<IReadOnlyList<AuditEntry>> LoadAuditEntriesAsync(string action)
+        {
+            await using var ctx = NewDbContext();
+            return await ctx.AuditEntries
+                .Where(a => a.Action == action)
+                .OrderBy(a => a.PerformedAt)
+                .ToListAsync();
+        }
+
+        public async Task<Fixture> WithNewTenantAsync()
+        {
+            var newTenantId = Guid.NewGuid();
+            var newTenantContext = new FixedTenantContext(newTenantId);
+            var options = new DbContextOptionsBuilder<StrgDbContext>().UseNpgsql(connectionString).Options;
+            await using var ctx = new StrgDbContext(options, newTenantContext, new MutableCurrentUser { UserId = Guid.Empty });
+            ctx.Tenants.Add(new Tenant { Id = newTenantId, Name = $"test-{newTenantId:N}" });
+            await ctx.SaveChangesAsync();
+            return new Fixture(connectionString, newTenantContext, newTenantId);
+        }
+    }
+}


### PR DESCRIPTION
Adds a per-user override layer on top of the existing tenant-wide Drive.IsDefault
flag so the inbox feature can resolve "this user's default drive" with a stable
fallback chain.

Decisions captured during planning (issue body was under-specified vs. the live
schema, where Drive has no UserId FK):
* Drive stays tenant-scoped. Drive.IsDefault is the tenant-wide bootstrap default
  (one per tenant) and is set automatically on the first non-soft-deleted drive
  created in the tenant.
* New UserDriveDefault(TenantId, UserId, DriveId) preference table — at most one
  row per (TenantId, UserId), enforced by a unique index — holds the per-user
  override. Picking a default is a user-level action (no Admin policy on the
  GraphQL mutation).
* Implementation matches the existing Drive CQRS slice: SetDefaultDriveCommand /
  Handler / Validator and GetDefaultDriveQuery / Handler in
  Strg.Application/Features/Drives, dispatched via IMediator from the GraphQL
  mutation. No IDriveService.
* GetDefaultDriveQuery resolution order: user's UserDriveDefault row →
  tenant-wide IsDefault drive → null.
* Cross-tenant DriveId lookups in SetDefaultDriveCommand throw NotFoundException
  (mapped by StrgErrorFilter to a top-level NOT_FOUND error), pinning the global
  tenant filter at the wire.

Migrations: AddDriveIsDefault (intentionally empty — Drives.IsDefault was
created in InitialCreate and is just being formally pinned for the AC) and
AddUserDriveDefault (creates the new table). Both must be applied on a fresh
DB before the API will start.

Tests:
* tests/Strg.Integration.Tests/Application/Drives/DriveDefaultHandlerTests.cs
  covers TC-001 through TC-005 against Testcontainers Postgres, plus a
  no-op-double-invoke audit assertion and a fall-back-chain assertion.
* tests/Strg.GraphQl.Tests/Mutations/DriveMutationsTests.cs adds happy-path
  and cross-tenant cases for setDefaultDrive.
* tests/Strg.GraphQl.Tests/SchemaTests.cs pins isDefault on the GraphQL
  Drive type.

Audit: new AuditActions.DriveDefaultChanged ("drive.default_changed") logs
per-user default selection separately from DriveUpdated, so audit readers can
tell tenant-flag mutations from user-preference picks.

Verification handoff (no .NET SDK available in this environment):
- Unit tests: NOT RUN (no SDK)
- Integration tests: NOT RUN (no SDK)
- Touched files & buckets:
  - Migrations + StrgDbContext.cs + StrgDbContextModelSnapshot.cs → S1 (full handoff)
  - CreateDriveHandler.cs → B3a (~CreateDriveHandler)
  - SetDefaultDriveHandler.cs / GetDefaultDriveHandler.cs → B3a (~SetDefaultDriveHandler, ~GetDefaultDriveHandler)
- Before you commit, please run:
  dotnet build
  dotnet test tests/Strg.Application.Tests tests/Strg.Core.Tests tests/Strg.GraphQl.Tests tests/Strg.Architecture.Tests tests/Strg.Api.Tests
  dotnet test tests/Strg.Integration.Tests
  dotnet ef database update --project src/Strg.Infrastructure --startup-project src/Strg.Api  # confirms hand-written migrations apply cleanly

Closes STRG-300 once verification passes.

https://claude.ai/code/session_01GvLFWJAkvGsRpyCPNTrEow