### PR TITLE
feat(plugins): STRG-089 — define strg-plugin.json manifest format and validation

### DIFF
--- a/src/Strg.Api/Plugins/PluginsConfiguration.cs
+++ b/src/Strg.Api/Plugins/PluginsConfiguration.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Strg.Plugin.Abstractions.Plugins;
+
+namespace Strg.Api.Plugins;
+
+/// <summary>
+/// Wires the <c>"Plugins"</c> configuration array into DI. Plugins are loaded ONLY when their
+/// id appears in this list — there is no directory scan and no implicit discovery, so this
+/// extension is the single point at which the operator's allowlist becomes visible to the rest
+/// of the host. The actual loader (<c>AssemblyLoadContext</c>-based isolation +
+/// permission-enforcing proxy) ships in v0.2; v0.1 ends with the validated catalogue registered
+/// as a singleton so the v0.2 loader has a stable surface to consume.
+/// </summary>
+public static class PluginsConfiguration
+{
+    /// <summary>Configuration root key for the plugin allowlist.</summary>
+    public const string SectionName = "Plugins";
+
+    /// <summary>
+    /// Reads <c>"Plugins"</c> as a list of <see cref="PluginConfig"/>, validates each entry
+    /// (reverse-DNS id, non-empty path), and registers the resulting catalogue as a singleton
+    /// <see cref="IReadOnlyList{T}"/> of <see cref="PluginConfig"/>. Throws
+    /// <see cref="InvalidOperationException"/> at startup on the first invalid entry — fail-fast
+    /// is mandatory here because a silently-dropped entry would mean the operator believes
+    /// they've enabled a plugin that the host never registers.
+    /// </summary>
+    public static IServiceCollection AddStrgPluginConfiguration(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configs = configuration.GetSection(SectionName).Get<List<PluginConfig>>() ?? [];
+
+        for (var i = 0; i < configs.Count; i++)
+        {
+            var entry = configs[i];
+
+            if (!PluginManifestValidator.IsValidPluginId(entry.Id))
+            {
+                throw new InvalidOperationException(
+                    $"Plugins[{i}].Id '{entry.Id}' is not a valid reverse-DNS plugin id (e.g. 'com.example.my-plugin').");
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Path))
+            {
+                throw new InvalidOperationException(
+                    $"Plugins[{i}].Path must be a non-empty filesystem path for plugin '{entry.Id}'.");
+            }
+        }
+
+        services.AddSingleton<IReadOnlyList<PluginConfig>>(configs);
+        return services;
+    }
+}

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -10,6 +10,7 @@ using Strg.Api.Auth;
 using Strg.Api.Cors;
 using Strg.Api.Endpoints;
 using Strg.Api.OpenApi;
+using Strg.Api.Plugins;
 using Strg.Api.RateLimiting;
 using Strg.Api.Security;
 using Strg.Application.Abstractions;
@@ -107,6 +108,13 @@ builder.Services.AddScoped<ITagRepository, TagRepository>();
 builder.Services.AddScoped<StrgTusStore>();
 builder.Services.Configure<StrgTusOptions>(builder.Configuration.GetSection("Strg:Upload"));
 builder.Services.TryAddSingleton(TimeProvider.System);
+
+// ---- Plugin allowlist (STRG-089) ----
+// Binds the "Plugins" config array (operator-supplied {Id, Path} entries) and validates each
+// entry's id as reverse-DNS. Registers the resulting catalogue as IReadOnlyList<PluginConfig>
+// so the v0.2 AssemblyLoadContext loader has a single, validated source of truth. No directory
+// scan: a stray DLL on disk does not run unless its id appears here.
+builder.Services.AddStrgPluginConfiguration(builder.Configuration);
 
 // ---- WebDAV (STRG-067/069) ----
 // Pass IConfiguration so WebDavOptions (PropfindInfinityMaxItems etc.) binds against the live

--- a/src/Strg.Api/appsettings.json
+++ b/src/Strg.Api/appsettings.json
@@ -28,5 +28,6 @@
     "Auth": { "PermitLimit": 10, "WindowSeconds": 60, "QueueLimit": 0 },
     "Global": { "PermitLimit": 300, "WindowSeconds": 60, "QueueLimit": 0 },
     "Upload": { "PermitLimit": 100, "WindowSeconds": 60, "QueueLimit": 0 }
-  }
+  },
+  "Plugins": []
 }

--- a/src/Strg.Plugin.Abstractions/Plugins/PluginConfig.cs
+++ b/src/Strg.Plugin.Abstractions/Plugins/PluginConfig.cs
@@ -1,0 +1,30 @@
+namespace Strg.Plugin.Abstractions.Plugins;
+
+/// <summary>
+/// One entry of the operator-supplied <c>"Plugins"</c> allowlist in <c>appsettings.json</c>.
+/// Plugins are loaded ONLY when their id appears in this list — there is no automatic discovery
+/// from a plugin directory, so a stray DLL on disk will not run unless the operator has
+/// explicitly opted into it via configuration.
+///
+/// <para><b>Shape note.</b> A class with <c>init</c>-only properties (rather than a positional
+/// record) so <see cref="Microsoft.Extensions.Configuration.ConfigurationBinder"/> can hydrate
+/// it without knowing about positional constructors — the binder writes through the public
+/// setters, which positional records do not expose.</para>
+/// </summary>
+public sealed class PluginConfig
+{
+    /// <summary>
+    /// Reverse-DNS plugin identifier. MUST match the <see cref="PluginManifest.Id"/> of the
+    /// plugin package found at <see cref="Path"/>. The id is validated through
+    /// <see cref="PluginManifestValidator.IsValidPluginId"/> at startup so a typo or path-
+    /// injection attempt fails fast rather than silently registering nothing.
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Filesystem directory containing the plugin's package (the <c>strg-plugin.json</c> and
+    /// the entry-point DLL). Validated as non-empty at startup; the loader (v0.2) is responsible
+    /// for refusing paths that escape its plugin root.
+    /// </summary>
+    public string Path { get; init; } = string.Empty;
+}

--- a/src/Strg.Plugin.Abstractions/Plugins/PluginManifest.cs
+++ b/src/Strg.Plugin.Abstractions/Plugins/PluginManifest.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Strg.Plugin.Abstractions.Plugins;
+
+/// <summary>
+/// Deserialised representation of a <c>strg-plugin.json</c> file shipped in a plugin package.
+/// All properties are <c>init</c>-only: a manifest is parsed once at startup and treated as
+/// immutable thereafter, so the host can keep references to it across the loader, DI graph,
+/// and admin UI without worrying about a plugin mutating its own metadata after registration.
+///
+/// <para>Validation lives in <see cref="PluginManifestValidator"/> — the DataAnnotation
+/// attributes on this type only express the rules a single field can self-check (presence,
+/// SemVer shape). Cross-field rules and security-critical pattern checks (reverse-DNS id,
+/// filename-only entry point, known plugin type) run in the validator.</para>
+/// </summary>
+public sealed record PluginManifest
+{
+    /// <summary>
+    /// Reverse-DNS plugin identifier (e.g. <c>"com.example.my-plugin"</c>). Acts as the stable
+    /// key used by the operator-supplied <c>"Plugins"</c> allowlist and by the loader's plugin
+    /// cache directory. Reverse-DNS form is enforced by <see cref="PluginManifestValidator"/>
+    /// (no path separators, no dots-only segments) — required to keep this safe to use as a
+    /// directory name on disk.
+    /// </summary>
+    [Required]
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>Human-readable plugin name; surfaced to the admin UI.</summary>
+    [Required]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>
+    /// SemVer version of the plugin itself (e.g. <c>"1.0.0"</c> or <c>"1.0.0-beta.1"</c>). The
+    /// regex anchors both ends to reject trailing garbage; <see cref="PluginManifestValidator"/>
+    /// re-parses the value numerically for ordering.
+    /// </summary>
+    [Required]
+    [RegularExpression(@"^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$")]
+    public string Version { get; init; } = string.Empty;
+
+    /// <summary>Short prose description; surfaced to the admin UI. Optional.</summary>
+    public string Description { get; init; } = string.Empty;
+
+    /// <summary>Author or vendor identifier; surfaced to the admin UI. Optional.</summary>
+    public string Author { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Lowest strg host version that satisfies this plugin's compatibility window. Compared
+    /// numerically by <see cref="PluginManifestValidator.IsCompatible"/>; a plugin listing
+    /// <c>"0.2.0"</c> here will be rejected by a <c>0.1.x</c> host.
+    /// </summary>
+    [Required]
+    public string MinStrgVersion { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Optional upper bound. <see langword="null"/> (or absent in JSON) means "no upper bound" —
+    /// the plugin is compatible with every host at or above <see cref="MinStrgVersion"/>.
+    /// </summary>
+    public string? MaxStrgVersion { get; init; }
+
+    /// <summary>
+    /// Filename of the entry-point DLL inside the plugin package (e.g.
+    /// <c>"Strg.Plugin.Example.dll"</c>). MUST be a bare filename with no directory components;
+    /// <see cref="PluginManifestValidator"/> enforces this — the loader resolves the file
+    /// relative to the configured plugin directory and any path components would let a malicious
+    /// manifest escape the plugin sandbox at load time.
+    /// </summary>
+    [Required]
+    public string EntryPoint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// One of the values in <see cref="PluginTypes.KnownTypes"/>. Determines which contract the
+    /// loader expects the entry-point assembly to implement.
+    /// </summary>
+    [Required]
+    public string PluginType { get; init; } = string.Empty;
+
+    /// <summary>Optional homepage URL; informational only.</summary>
+    public string? Homepage { get; init; }
+
+    /// <summary>Optional SPDX license identifier; informational only.</summary>
+    public string? License { get; init; }
+
+    /// <summary>
+    /// Capability strings the plugin declares it needs (e.g. <c>"storage.read"</c>,
+    /// <c>"storage.write"</c>). Enforced at runtime in v0.2 by the
+    /// <c>PermissionEnforcingPluginProxy</c>; in v0.1 the values are recorded for forward
+    /// compatibility but no enforcement runs yet.
+    /// </summary>
+    public IReadOnlyList<string> Permissions { get; init; } = [];
+}

--- a/src/Strg.Plugin.Abstractions/Plugins/PluginManifestValidator.cs
+++ b/src/Strg.Plugin.Abstractions/Plugins/PluginManifestValidator.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Strg.Plugin.Abstractions.Plugins;
+
+/// <summary>
+/// Static helpers for validating a <see cref="PluginManifest"/> and for deciding whether a
+/// host version satisfies the manifest's compatibility window. Lives in this contract layer
+/// (rather than the loader) so plugin authors can run the same checks at build time that the
+/// host runs at startup — same code path, no drift between the two surfaces.
+/// </summary>
+public static partial class PluginManifestValidator
+{
+    /// <summary>
+    /// Reverse-DNS pattern for <see cref="PluginManifest.Id"/>. Each segment must start with a
+    /// letter or digit, may contain hyphens internally, and must not end on a hyphen; segments
+    /// are joined with a single dot, and at least two segments are required (so <c>"plugin"</c>
+    /// alone fails — the leading reverse-DNS authority is mandatory). The pattern intentionally
+    /// rejects path separators (<c>/</c>, <c>\</c>), dots-only segments (<c>".."</c>), and
+    /// whitespace, which is the security-checklist guarantee — the id is later used as a
+    /// directory name on disk, and any of those would let a malicious manifest escape the
+    /// plugin cache root.
+    /// </summary>
+    [GeneratedRegex(@"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$")]
+    private static partial Regex ReverseDnsRegex();
+
+    [GeneratedRegex(@"^(\d+)\.(\d+)\.(\d+)(?:-[A-Za-z0-9.-]+)?$")]
+    private static partial Regex SemVerRegex();
+
+    /// <summary>
+    /// Runs the DataAnnotation attributes on <see cref="PluginManifest"/> plus three layered
+    /// checks the attributes can't express on their own:
+    /// <list type="number">
+    ///   <item><see cref="PluginManifest.Id"/> matches the reverse-DNS pattern (no path
+    ///         separators, no <c>".."</c> segments) — Security checklist guarantee.</item>
+    ///   <item><see cref="PluginManifest.EntryPoint"/> is a bare filename with no directory
+    ///         components — Security checklist guarantee.</item>
+    ///   <item><see cref="PluginManifest.PluginType"/> is one of <see cref="PluginTypes.KnownTypes"/>.</item>
+    /// </list>
+    /// Returns <see langword="true"/> only when both layers pass; <paramref name="errors"/> is
+    /// populated with one human-readable message per violation either way.
+    /// </summary>
+    public static bool Validate(PluginManifest manifest, out IReadOnlyList<string> errors)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        var collected = new List<string>();
+        var dataAnnotationResults = new List<ValidationResult>();
+        var context = new ValidationContext(manifest);
+
+        // validateAllProperties:true — the default would short-circuit on the first failure per
+        // property, but operators benefit from the full list (a manifest can be missing several
+        // required fields at once on first author).
+        Validator.TryValidateObject(manifest, context, dataAnnotationResults, validateAllProperties: true);
+        foreach (var result in dataAnnotationResults)
+        {
+            collected.Add(result.ErrorMessage ?? "Unknown manifest validation error.");
+        }
+
+        // The DataAnnotation [Required] check considers an empty string a violation, so the
+        // pattern checks below only run when the field is present. Skipping them on a missing
+        // field would otherwise re-report "Id is required" twice (once from DataAnnotations,
+        // once from the regex mismatch on empty input).
+        if (!string.IsNullOrEmpty(manifest.Id) && !IsValidPluginId(manifest.Id))
+        {
+            collected.Add($"Plugin id '{manifest.Id}' must be reverse-DNS (e.g. 'com.example.my-plugin'); path characters and '..' segments are rejected.");
+        }
+
+        if (!string.IsNullOrEmpty(manifest.EntryPoint) && !IsFilenameOnly(manifest.EntryPoint))
+        {
+            collected.Add($"Plugin entryPoint '{manifest.EntryPoint}' must be a bare filename with no directory components.");
+        }
+
+        if (!string.IsNullOrEmpty(manifest.PluginType) && !PluginTypes.KnownTypes.Contains(manifest.PluginType))
+        {
+            collected.Add($"Plugin type '{manifest.PluginType}' is not one of the known values: {string.Join(", ", PluginTypes.KnownTypes)}.");
+        }
+
+        errors = collected;
+        return collected.Count == 0;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="currentStrgVersion"/> falls inside
+    /// the manifest's <c>[MinStrgVersion, MaxStrgVersion]</c> window (both bounds inclusive).
+    /// A <see langword="null"/> <see cref="PluginManifest.MaxStrgVersion"/> means "no upper
+    /// bound". Throws <see cref="FormatException"/> if any version string is not parseable as
+    /// <c>major.minor.patch</c>.
+    /// </summary>
+    public static bool IsCompatible(PluginManifest manifest, string currentStrgVersion)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+        ArgumentException.ThrowIfNullOrWhiteSpace(currentStrgVersion);
+
+        var current = ParseSemVer(currentStrgVersion);
+        var min = ParseSemVer(manifest.MinStrgVersion);
+
+        if (Compare(current, min) < 0)
+        {
+            return false;
+        }
+
+        if (manifest.MaxStrgVersion is null)
+        {
+            return true;
+        }
+
+        var max = ParseSemVer(manifest.MaxStrgVersion);
+        return Compare(current, max) <= 0;
+    }
+
+    /// <summary>
+    /// Reverse-DNS pattern check for <see cref="PluginManifest.Id"/>. Exposed so the
+    /// configuration-binding layer (<c>AddStrgPluginConfiguration</c> in Strg.Api) can re-use
+    /// the exact same rule on the operator-supplied <c>"Plugins"</c> allowlist — a config entry
+    /// whose <c>Id</c> matches no manifest in the eventual catalogue is still required to be a
+    /// safe directory name.
+    /// </summary>
+    public static bool IsValidPluginId(string id)
+    {
+        return !string.IsNullOrEmpty(id) && ReverseDnsRegex().IsMatch(id);
+    }
+
+    private static bool IsFilenameOnly(string entryPoint)
+    {
+        // Catch every path-component shape: directory separators, alt separators, parent-dir
+        // tokens, and any input where Path.GetFileName returns something different from the
+        // input. Done as four explicit checks rather than relying on Path.GetFileName alone
+        // because Path.GetFileName silently treats inputs ending in a separator as having no
+        // filename and returns an empty string — which would equal "" but not equal the
+        // original entryPoint, so the equality check below catches it. Keeping the explicit
+        // checks makes the intent (and the diagnostic) obvious.
+        if (entryPoint.Contains('/') || entryPoint.Contains('\\'))
+        {
+            return false;
+        }
+        if (entryPoint == "." || entryPoint == "..")
+        {
+            return false;
+        }
+        return string.Equals(Path.GetFileName(entryPoint), entryPoint, StringComparison.Ordinal);
+    }
+
+    private static (int Major, int Minor, int Patch) ParseSemVer(string version)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(version);
+
+        var match = SemVerRegex().Match(version);
+        if (!match.Success)
+        {
+            throw new FormatException($"Version '{version}' is not a valid SemVer string (expected 'major.minor.patch').");
+        }
+
+        var major = int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+        var minor = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+        var patch = int.Parse(match.Groups[3].Value, CultureInfo.InvariantCulture);
+        return (major, minor, patch);
+    }
+
+    private static int Compare((int Major, int Minor, int Patch) left, (int Major, int Minor, int Patch) right)
+    {
+        var major = left.Major.CompareTo(right.Major);
+        if (major != 0)
+        {
+            return major;
+        }
+        var minor = left.Minor.CompareTo(right.Minor);
+        if (minor != 0)
+        {
+            return minor;
+        }
+        return left.Patch.CompareTo(right.Patch);
+    }
+}

--- a/src/Strg.Plugin.Abstractions/Plugins/PluginTypes.cs
+++ b/src/Strg.Plugin.Abstractions/Plugins/PluginTypes.cs
@@ -1,0 +1,51 @@
+using System.Collections.Frozen;
+
+namespace Strg.Plugin.Abstractions.Plugins;
+
+/// <summary>
+/// Canonical <c>pluginType</c> values for <see cref="PluginManifest.PluginType"/>. Each constant
+/// names the contract surface the manifest's entry-point assembly is expected to implement; the
+/// loader uses the value to decide which DI registration path to take when the plugin is
+/// activated. <see cref="KnownTypes"/> is the membership oracle for manifest validation — any
+/// value outside this set fails <see cref="PluginManifestValidator.Validate"/>.
+/// </summary>
+public static class PluginTypes
+{
+    /// <summary>Plugin contributes one or more <c>IStorageProvider</c> implementations.</summary>
+    public const string Storage = "storage";
+
+    /// <summary>Plugin contributes an <c>IAuthConnector</c> (LDAP/SAML/OAuth2 adapter).</summary>
+    public const string Auth = "auth";
+
+    /// <summary>Plugin contributes an <c>ISearchProvider</c> (Elasticsearch, Meilisearch, …).</summary>
+    public const string Search = "search";
+
+    /// <summary>Plugin contributes an <c>IEndpointModule</c> mounted under <c>/plugins/{name}</c>.</summary>
+    public const string Endpoint = "endpoint";
+
+    /// <summary>Plugin contributes an <c>IAITagger</c> for automated file tagging.</summary>
+    public const string AiTagger = "ai-tagger";
+
+    /// <summary>Plugin contributes an <c>IFederationProvider</c> (e.g. ActivityPub).</summary>
+    public const string Federation = "federation";
+
+    /// <summary>Plugin implements multiple contracts; the loader probes the entry assembly for each.</summary>
+    public const string Generic = "generic";
+
+    /// <summary>
+    /// Frozen ordinal set of the seven canonical types above. <see cref="FrozenSet{T}"/> is used
+    /// rather than a plain <see cref="HashSet{T}"/> because the membership lookup runs once per
+    /// configured plugin at startup AND every time a manifest is re-validated; FrozenSet's read-
+    /// optimised layout keeps this on the cheap branch even as the type list grows.
+    /// </summary>
+    public static readonly FrozenSet<string> KnownTypes = new[]
+    {
+        Storage,
+        Auth,
+        Search,
+        Endpoint,
+        AiTagger,
+        Federation,
+        Generic,
+    }.ToFrozenSet(StringComparer.Ordinal);
+}

--- a/tests/Strg.Api.Tests/Plugins/PluginConfigBindingTests.cs
+++ b/tests/Strg.Api.Tests/Plugins/PluginConfigBindingTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Strg.Api.Plugins;
+using Strg.Plugin.Abstractions.Plugins;
+using Xunit;
+
+namespace Strg.Api.Tests.Plugins;
+
+/// <summary>
+/// STRG-089 — exercises <see cref="PluginsConfiguration.AddStrgPluginConfiguration"/> end-to-end.
+/// The architectural guarantee under test is the TC-005 contract: plugins NOT listed in the
+/// <c>"Plugins"</c> config array must not surface as <see cref="PluginConfig"/> instances even
+/// when their files are present on disk. The test exercises the full binding + validation path
+/// rather than just the raw <see cref="IConfiguration"/> binder so a regression in the validation
+/// rules is caught here, not in production startup.
+/// </summary>
+public sealed class PluginConfigBindingTests
+{
+    // TC-005 — only entries in the "Plugins" config array are surfaced.
+    [Fact]
+    public void Bind_OnlyConfiguredEntries_AreRegistered()
+    {
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Plugins:0:Id"] = "com.example.configured",
+            ["Plugins:0:Path"] = "/opt/strg/plugins/configured/",
+        });
+        var services = new ServiceCollection();
+
+        services.AddStrgPluginConfiguration(configuration);
+
+        var registered = services.BuildServiceProvider().GetRequiredService<IReadOnlyList<PluginConfig>>();
+        registered.Should().HaveCount(1);
+        registered[0].Id.Should().Be("com.example.configured");
+        registered[0].Path.Should().Be("/opt/strg/plugins/configured/");
+    }
+
+    [Fact]
+    public void Bind_MissingSection_RegistersEmptyList()
+    {
+        var configuration = BuildConfig(new Dictionary<string, string?>());
+        var services = new ServiceCollection();
+
+        services.AddStrgPluginConfiguration(configuration);
+
+        var registered = services.BuildServiceProvider().GetRequiredService<IReadOnlyList<PluginConfig>>();
+        registered.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Bind_InvalidId_ThrowsAtStartup()
+    {
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Plugins:0:Id"] = "evil/../path",
+            ["Plugins:0:Path"] = "/opt/strg/plugins/evil/",
+        });
+        var services = new ServiceCollection();
+
+        var act = () => services.AddStrgPluginConfiguration(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*reverse-DNS*");
+    }
+
+    [Fact]
+    public void Bind_EmptyPath_ThrowsAtStartup()
+    {
+        var configuration = BuildConfig(new Dictionary<string, string?>
+        {
+            ["Plugins:0:Id"] = "com.example.configured",
+            ["Plugins:0:Path"] = "",
+        });
+        var services = new ServiceCollection();
+
+        var act = () => services.AddStrgPluginConfiguration(configuration);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Path*");
+    }
+
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/tests/Strg.Core.Tests/Plugins/PluginManifestTests.cs
+++ b/tests/Strg.Core.Tests/Plugins/PluginManifestTests.cs
@@ -1,0 +1,118 @@
+namespace Strg.Core.Tests.Plugins;
+
+using System.Text.Json;
+using FluentAssertions;
+using Strg.Plugin.Abstractions.Plugins;
+using Xunit;
+
+public sealed class PluginManifestTests
+{
+    private const string ValidJson =
+        """
+        {
+          "id": "com.example.my-plugin",
+          "name": "My Plugin",
+          "version": "1.0.0",
+          "description": "A sample plugin for strg",
+          "author": "Example Corp",
+          "minStrgVersion": "0.1.0",
+          "maxStrgVersion": null,
+          "entryPoint": "Strg.Plugin.Example.dll",
+          "pluginType": "storage",
+          "homepage": "https://example.com/my-plugin",
+          "license": "MIT",
+          "permissions": ["storage.read", "storage.write"]
+        }
+        """;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // TC-001 — valid manifest deserializes with every field populated.
+    [Fact]
+    public void Deserialize_ValidJson_AllFieldsPopulated()
+    {
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(ValidJson, JsonOptions);
+
+        manifest.Should().NotBeNull();
+        manifest!.Id.Should().Be("com.example.my-plugin");
+        manifest.Name.Should().Be("My Plugin");
+        manifest.Version.Should().Be("1.0.0");
+        manifest.Description.Should().Be("A sample plugin for strg");
+        manifest.Author.Should().Be("Example Corp");
+        manifest.MinStrgVersion.Should().Be("0.1.0");
+        manifest.MaxStrgVersion.Should().BeNull();
+        manifest.EntryPoint.Should().Be("Strg.Plugin.Example.dll");
+        manifest.PluginType.Should().Be("storage");
+        manifest.Homepage.Should().Be("https://example.com/my-plugin");
+        manifest.License.Should().Be("MIT");
+        manifest.Permissions.Should().Equal("storage.read", "storage.write");
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeTrue();
+        errors.Should().BeEmpty();
+    }
+
+    // TC-003 — missing entryPoint surfaces a validation error.
+    [Fact]
+    public void Validate_MissingEntryPoint_ReturnsError()
+    {
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            """
+            {
+              "id": "com.example.my-plugin",
+              "name": "My Plugin",
+              "version": "1.0.0",
+              "minStrgVersion": "0.1.0",
+              "pluginType": "storage"
+            }
+            """,
+            JsonOptions)!;
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        // DataAnnotation [Required] message uses the property name.
+        errors.Should().Contain(e => e.Contains("EntryPoint"));
+    }
+
+    // TC-004 — unknown pluginType is rejected.
+    [Fact]
+    public void Validate_UnknownPluginType_ReturnsError()
+    {
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            """
+            {
+              "id": "com.example.my-plugin",
+              "name": "My Plugin",
+              "version": "1.0.0",
+              "minStrgVersion": "0.1.0",
+              "entryPoint": "Strg.Plugin.Example.dll",
+              "pluginType": "magic"
+            }
+            """,
+            JsonOptions)!;
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("'magic'"));
+    }
+
+    [Fact]
+    public void Validate_MalformedVersion_ReturnsError()
+    {
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(
+            """
+            {
+              "id": "com.example.my-plugin",
+              "name": "My Plugin",
+              "version": "1.0",
+              "minStrgVersion": "0.1.0",
+              "entryPoint": "Strg.Plugin.Example.dll",
+              "pluginType": "storage"
+            }
+            """,
+            JsonOptions)!;
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("Version"));
+    }
+}

--- a/tests/Strg.Core.Tests/Plugins/PluginManifestValidatorTests.cs
+++ b/tests/Strg.Core.Tests/Plugins/PluginManifestValidatorTests.cs
@@ -1,0 +1,125 @@
+namespace Strg.Core.Tests.Plugins;
+
+using FluentAssertions;
+using Strg.Plugin.Abstractions.Plugins;
+using Xunit;
+
+public sealed class PluginManifestValidatorTests
+{
+    private static PluginManifest BaseManifest() => new()
+    {
+        Id = "com.example.my-plugin",
+        Name = "My Plugin",
+        Version = "1.0.0",
+        MinStrgVersion = "0.1.0",
+        EntryPoint = "Strg.Plugin.Example.dll",
+        PluginType = PluginTypes.Storage,
+    };
+
+    // TC-002 — plugin requiring 0.2.0 not loaded by 0.1.0 strg.
+    [Fact]
+    public void IsCompatible_HostBelowMin_ReturnsFalse()
+    {
+        var manifest = BaseManifest() with { MinStrgVersion = "0.2.0" };
+
+        PluginManifestValidator.IsCompatible(manifest, currentStrgVersion: "0.1.0").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCompatible_HostAtMin_ReturnsTrue()
+    {
+        var manifest = BaseManifest() with { MinStrgVersion = "0.2.0" };
+
+        PluginManifestValidator.IsCompatible(manifest, currentStrgVersion: "0.2.0").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCompatible_HostAboveMaxBound_ReturnsFalse()
+    {
+        var manifest = BaseManifest() with { MinStrgVersion = "0.1.0", MaxStrgVersion = "0.2.0" };
+
+        PluginManifestValidator.IsCompatible(manifest, currentStrgVersion: "0.3.0").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCompatible_NullMaxBound_NoUpperLimit()
+    {
+        var manifest = BaseManifest() with { MinStrgVersion = "0.1.0", MaxStrgVersion = null };
+
+        PluginManifestValidator.IsCompatible(manifest, currentStrgVersion: "99.0.0").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCompatible_MalformedVersion_Throws()
+    {
+        var manifest = BaseManifest() with { MinStrgVersion = "not-a-version" };
+
+        var act = () => PluginManifestValidator.IsCompatible(manifest, currentStrgVersion: "0.1.0");
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Validate_IdWithPathChars_ReturnsError()
+    {
+        // The id is later used as a directory name; the security checklist requires that
+        // path separators and ".." segments cannot smuggle through deserialization.
+        var manifest = BaseManifest() with { Id = "com.example/../evil" };
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("reverse-DNS"));
+    }
+
+    [Fact]
+    public void Validate_IdSingleSegment_ReturnsError()
+    {
+        var manifest = BaseManifest() with { Id = "plugin" };
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("reverse-DNS"));
+    }
+
+    [Theory]
+    [InlineData("../Strg.Plugin.Example.dll")]
+    [InlineData("subdir/Strg.Plugin.Example.dll")]
+    [InlineData("subdir\\Strg.Plugin.Example.dll")]
+    [InlineData("..")]
+    public void Validate_EntryPointWithPathComponent_ReturnsError(string entryPoint)
+    {
+        var manifest = BaseManifest() with { EntryPoint = entryPoint };
+
+        PluginManifestValidator.Validate(manifest, out var errors).Should().BeFalse();
+        errors.Should().Contain(e => e.Contains("entryPoint"));
+    }
+
+    [Fact]
+    public void Validate_AllKnownPluginTypes_AreAccepted()
+    {
+        // Pin the public catalogue: every value in PluginTypes.KnownTypes must round-trip
+        // through the validator. A regression here is the failure mode where a new type is
+        // added to the const surface but forgotten in KnownTypes (or vice versa).
+        foreach (var type in PluginTypes.KnownTypes)
+        {
+            var manifest = BaseManifest() with { PluginType = type };
+            PluginManifestValidator.Validate(manifest, out _).Should().BeTrue($"plugin type '{type}' is in KnownTypes");
+        }
+    }
+
+    [Fact]
+    public void IsValidPluginId_AcceptsReverseDns()
+    {
+        PluginManifestValidator.IsValidPluginId("com.example.my-plugin").Should().BeTrue();
+        PluginManifestValidator.IsValidPluginId("io.acme.search-provider").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("com.example/../evil")]
+    [InlineData("plugin")]
+    [InlineData("..")]
+    [InlineData("")]
+    [InlineData("Com.Example.Plugin")] // uppercase rejected — directory case-sensitivity on linux
+    [InlineData("com..example")]       // empty middle segment
+    public void IsValidPluginId_RejectsBadIds(string id)
+    {
+        PluginManifestValidator.IsValidPluginId(id).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Adds the metadata contract and validation layer that the v0.2 plugin loader
will consume. Plugins are loaded ONLY when their id is listed in the
operator-supplied "Plugins" config array — no directory scanning, no implicit
discovery.

Plugin.Abstractions/Plugins:
- PluginManifest (sealed record, init-only) with [Required] / [RegularExpression]
  attributes describing the strg-plugin.json shape (id, name, version,
  minStrgVersion, maxStrgVersion, entryPoint, pluginType, permissions, …).
- PluginManifestValidator: DataAnnotation pass + reverse-DNS id check
  (no path separators, no '..' segments — security checklist guarantee),
  filename-only entryPoint check, known-pluginType membership, plus an
  inline major.minor.patch SemVer parser for IsCompatible (no external
  Semver NuGet — Plugin.Abstractions stays at zero external deps).
- PluginTypes: frozen catalogue of the seven canonical pluginType strings.
- PluginConfig: {Id, Path} record bound from "Plugins:N" entries.

Strg.Api:
- AddStrgPluginConfiguration extension reads "Plugins", validates each
  entry's id (reverse-DNS) and non-empty path, and registers the catalogue
  as IReadOnlyList<PluginConfig> for the v0.2 loader.
- Program.cs wires the extension; appsettings.json gets an empty default.

Tests cover TC-001 through TC-005 plus negative paths for path-injection
attempts in id/entryPoint, malformed SemVer, and the no-directory-scan
contract.