### PR TITLE
docs(thumbnails): Phase 15 tranche — 16 child issues, ADR, README build-order (#52)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,9 @@
     <PackageVersion Include="MassTransit.EntityFrameworkCore" Version="8.5.9" />
     <!-- TUS upload -->
     <PackageVersion Include="tusdotnet" Version="2.11.1" />
+    <!-- Image processing (STRG-336/337) — Magick.NET-Q8-x64 ships with native ImageMagick + libwebp;
+         libheif is a SYSTEM dependency (libheif1 + plugins) installed in the Docker base image. -->
+    <PackageVersion Include="Magick.NET-Q8-x64" Version="14.4.0" />
     <!-- WebDAV -->
     <PackageVersion Include="WebDav.Server" Version="15.4.16086" />
     <!-- Logging -->

--- a/docs/architecture/06-thumbnails.md
+++ b/docs/architecture/06-thumbnails.md
@@ -1,0 +1,172 @@
+---
+title: "Thumbnail Generation"
+tags: [architecture, thumbnails, plugins, phase-15]
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# Thumbnail Generation
+
+## Design
+
+strg generates image thumbnails asynchronously after each upload. Three variants are produced (`thumb=256`, `small=512`, `medium=1024`), output as WebP at quality 82, letterboxed onto a white square canvas. Generation runs inside the API host process for v1; `STRG-344` documents the runway for moving to a sandboxed worker process.
+
+The subsystem is structured around three contracts in `Strg.Core`:
+
+- `IThumbnailGenerator` — handlers self-declare via `CanHandle(mimeType, magicBytes)`. The consumer never branches on MIME.
+- `IThumbnailGeneratorRegistry` — first-registered match wins.
+- `IThumbnailService` — orchestrator the consumer talks to.
+
+Behind these, `Strg.Infrastructure` ships `MagickNetImageThumbnailer` (Apache 2.0 licensed Magick.NET, including native libheif for HEIC). Phase 16 will add a PDF generator and an Office generator without changing the consumer, the API, the database schema, or any of the events.
+
+A `ThumbnailEntry` row tracks each generated thumbnail. The row carries `Status` (`Pending` / `Ready` / `Failed` / `Unsupported`), the storage key, dimensions, and a `GeneratorVersion` field that lets us trigger forced regeneration when the algorithm changes.
+
+---
+
+## Decisions
+
+| # | Decision | Options | Chosen |
+|---|----------|---------|--------|
+| D1 | When to generate | eager / async / lazy | **async** — upload latency matters more than first-view latency |
+| D2 | What stores the thumbnail blob | same `IStorageProvider` + namespaced key / dedicated provider / inline bytea | **same provider, `thumbnails/{driveId}/{fileVersionId}/{variant}.{format}`** |
+| D3 | What tracks state/metadata | new `ThumbnailEntry` entity / fields on `FileVersion` / cache-only | **new `ThumbnailEntry` entity** |
+| D4 | Encryption | plaintext always / inherit drive posture / fresh DEK | **inherit drive posture** |
+| D5 | Image library | Magick.NET / NetVips / SkiaSharp / ImageSharp | **Magick.NET (Apache 2.0)** behind `IImageThumbnailer` interface. ImageSharp's license change is a ship-stopper |
+| D6 | PDF library (Phase 16) | PDFtoImage / Docnet.Core / PdfPig | **PDFtoImage or Docnet.Core** — PdfPig can't rasterize |
+| D7 | Office documents (Phase 16) | LibreOffice headless / Office Interop / skip | **LibreOffice headless, opt-in, feature-flagged** |
+| D8 | Variants | fixed vs on-demand | **fixed `[thumb=256, small=512, medium=1024]`** |
+| D9 | Output format | WebP only / WebP + JPEG fallback / AVIF | **WebP primary, JPEG fallback only if UA can't** |
+| D10 | Crop vs contain | letterbox / cover / per-variant | **contain/letterbox, white background** |
+| D11 | What types get thumbnails | whitelist MIME / sniff magic bytes / handler-declared | **handler-declared via `IThumbnailGenerator.CanHandle(mimeType, magicBytes)`** |
+| D12 | MIME trust | trust client / sniff at upload / sniff at thumbnail time | **sniff at thumbnail time (magic bytes)** |
+| D13 | Generation failure mode | retry forever / mark unsupported / mark failed+retry budget | **three-state: Ready / Failed / Unsupported** |
+| D14 | Resource safeguards | nothing / pixel-cap + timeout + mem cap / process isolation | **pixel-area cap + timeout + max-source-size, in-proc for v1**; sandbox as follow-up |
+| D15 | Backfill for existing files | leave empty / admin-triggered / auto on first access | **admin-triggered bulk consumer, idempotent** |
+| D16 | Quota accounting | count against user / operator absorbs | **operator absorbs** (parallels encryption overhead) |
+| D17 | Encrypted drives in v1 | ship decryption-aware generator / defer | **defer** — no public decryption abstraction exists yet |
+
+---
+
+## Image Library Selection (D5)
+
+| Library | License | HEIC | EXIF | Streaming | Verdict |
+|---|---|---|---|---|---|
+| Magick.NET (`Magick.NET-Q8-x64`) | Apache 2.0 | Yes (native libheif) | Full | Yes | **Chosen** |
+| NetVips | LGPL | Yes (libheif) | Full | Yes | LGPL not aligned with project preference for permissive dependencies |
+| SkiaSharp | MIT | No | No EXIF | Yes | HEIC blocks v1 |
+| ImageSharp (Six Labors) | Six Labors Split License | Yes | Full | Yes | **License-change ship-stopper.** The Six Labors split license shifted commercial use behind a paid plan in late 2024 — incompatible with the project's permissive posture |
+
+The thumbnailer sits behind `IThumbnailGenerator`. If a future ImageMagick CVE forces a swap, the contract is unchanged — only the implementation is replaced.
+
+**Native dependencies.** `Magick.NET-Q8-x64` includes most format support, but HEIC requires the host's libheif system library. The Docker base image installs `libheif1`, `libheif-plugin-aomdec`, and `libheif-plugin-libde265`. If libheif is absent at runtime, HEIC reads fall through to `SourceCorrupt` — graceful degradation rather than a crash.
+
+**Quality and bit depth.** Q8 is sufficient for thumbnails at 256/512/1024 px. Q16 doubles the in-memory bitmap size for no perceptual gain at these dimensions.
+
+---
+
+## Quota Policy (D16)
+
+Thumbnail bytes do **not** count against the user's quota. The operator absorbs the cost. This parallels the encryption-overhead precedent: `FileVersion.BlobSizeBytes` already excludes the AES-GCM frame overhead from user-visible quota, on the same reasoning — operator-driven storage amplification is not the user's concern.
+
+If thumbnail bytes were charged to users, every algorithm change (e.g., bumping `WebPQuality` from 82 to 90) would silently shift quota usage across the entire fleet. Centralising the cost on the operator decouples that knob from the user contract.
+
+The thumbnail blobs are still subject to per-drive storage limits at the storage-provider layer. Operators who run tight on space can reduce variant count or quality via `ThumbnailOptions`.
+
+---
+
+## Encrypted-Drive Carve-out (D17)
+
+A drive with `EncryptionEnabled = true` stores ciphertext blobs that only the per-version `FileKey`-derived DEK can decrypt. The thumbnail consumer reads via `IStorageProvider.ReadAsync`, which on an encrypted drive returns ciphertext bytes — not plaintext.
+
+In v1, no public decryption abstraction exists. `ChunkedGcmDecryptStream` is `internal sealed` and used only inside `AesGcmFileWriter`'s write-back self-test. The consumer cannot decrypt the source without an `IEncryptingFileReader` extraction — which is its own substantial piece of work (it must integrate with the `FileKey` resolver, replicate the AAD framing, and gracefully handle key-rotation events).
+
+The carve-out: when `drive.EncryptionEnabled == true`, the consumer writes a single `ThumbnailEntry { Status = Unsupported, ErrorReason = "encrypted-drive-not-yet-supported" }` and exits. The REST endpoint serves 404 for the missing thumbnail; GraphQL surfaces `status: UNSUPPORTED, errorReason: "encrypted-drive-not-yet-supported"` so clients can render an icon.
+
+A future issue (planned as STRG-347) extracts `IEncryptingFileReader` and unblocks both encrypted-drive thumbnails AND the regular encrypted-drive download path. That work is the prerequisite, not the thumbnail subsystem itself.
+
+---
+
+## Extension Map (Phase 16 Readiness)
+
+The v1 architecture is engineered so the Phase 16 PDF and Office generators land additively. **No** consumer change, API change, schema change, or event change is needed:
+
+| Extension point | Where | What changes when PDF (Phase 16) lands |
+|---|---|---|
+| `IThumbnailGenerator.CanHandle` | `Strg.Core/Services/IThumbnailGenerator.cs` | New generator self-declares `application/pdf`. Consumer untouched. |
+| `MimeSniffer` whitelist | `Strg.Core/Media/MimeSniffer.cs` | `%PDF-` already covered. No change. |
+| `ThumbnailStorageKeyBuilder` | `Strg.Core/Services/ThumbnailStorageKeyBuilder.cs` | `Format` parameterizes; same scheme. No change. |
+| `ThumbnailEntry.Format` | `Strg.Core/Domain/ThumbnailEntry.cs` | Free-text column. No schema migration. |
+| `IConsumer<ThumbnailGenerationRequestedEvent>` | backfill consumer | Same event covers PDF backfill. No change. |
+| `Thumbnails:PdfEnabled` config flag | `ThumbnailOptions` | Already present in v1; flips on. |
+| `Thumbnails:OfficeEnabled` config flag | `ThumbnailOptions` | Already present in v1; flips on. |
+
+A test in the v1 suite proves the contract: a fake generator registered via DI is routed to by the backfill mutation without any code in the consumer / API / DB layer changing.
+
+---
+
+## Event Flow
+
+| Event | Handler | Action |
+|---|---|---|
+| `FileUploadedEvent` | `ThumbnailGenerationConsumer` | Generate per-variant thumbnails |
+| `ThumbnailGenerationRequestedEvent` | `ThumbnailGenerationConsumer` | Backfill (admin-triggered or algorithm-bump regen) |
+| `FileDeletedEvent` | `ThumbnailCleanupConsumer` | Soft-delete thumbnail rows + best-effort blob delete |
+| `ThumbnailReadyEvent` | `GraphQlSubscriptionPublisher` | Push to `thumbnailReady(fileId)` GraphQL subscribers |
+
+The backfill event is **dedicated**, NOT a republished `FileUploadedEvent`, because republishing would double-write `AuditEntry` rows via `AuditLogConsumer`. The two events share the consumer; only the upload path triggers audit.
+
+Consumer guarantees apply uniformly:
+
+- **At-least-once delivery.** Idempotency via `(FileVersionId, Variant, Format)` unique index, name pinned in `ThumbnailConstraintNames.UniqueIndex`. The consumer catches `PostgresException.SqlState == "23505"` with exact `ConstraintName` equality (mirror of the audit consumer's pattern).
+- **Outbox semantics.** Every `IPublishEndpoint.Publish` call happens BEFORE `SaveChangesAsync`, so the event and the row update commit atomically.
+- **Tenant from payload.** The consumer never reads ambient `ITenantContext` (which is empty in consumer scope); tenant ID is on every event payload.
+
+---
+
+## Resource Safeguards
+
+Three layered checks defend against decompression bombs and runaway generators:
+
+1. **Source-size cap.** `FileVersion.Size > Thumbnails:MaxSourceSizeBytes` (default 256 MiB) → `Unsupported{too-large}`. Rejected before any blob read.
+2. **Pixel-area cap.** `MagickImageInfo` reads the first 64 KiB to extract dimensions, then `Width * Height > Thumbnails:MaxPixelArea` (default 100 MP) → `ResourceLimitExceeded` → `Unsupported{pixel-cap}`. Rejected before full decode.
+3. **Generation timeout.** Per-call `CancellationTokenSource(Thumbnails:GenerationTimeoutSeconds)` (default 30 s) linked with the consumer's CT → `TimedOut` → `Failed{timeout}`. Distinguishes from caller cancellation.
+
+The timeout cancellation is observable via the `strg_thumbnails_generated_total{status=timed-out}` counter, so operators can tune the limit against real workloads without modifying code.
+
+For long-term hardening (process isolation, sandboxed worker), see `07-thumbnail-sandboxing.md` (planned design document — the current safeguards are deliberately conservative because in-process is the v1 ceiling).
+
+---
+
+## Out of Scope (Phase 15)
+
+- **PDF rasterization.** Reserved for Phase 16. PDFium / Docnet.Core integration with the same `IThumbnailGenerator` contract.
+- **Office documents.** Reserved for Phase 16. LibreOffice headless out-of-process, opt-in via `Thumbnails:OfficeEnabled`.
+- **Encrypted-drive thumbnails.** Carved out per D17. Requires `IEncryptingFileReader` extraction first (planned).
+- **RAW formats** (CR2/NEF/ARW/DNG). Magick.NET can extract embedded JPEG previews but RAW handling is its own size budget. Deferred.
+- **SVG input.** Security swamp (embedded scripts, external refs). If shipped, must rasterize via librsvg with network and script disabled.
+- **Animated thumbnails.** First frame only. Animated thumbnails are a distinct UX feature.
+- **Generic fallback icons.** Backend reports `Unsupported`; the client picks the icon. Backend stays UI-agnostic.
+- **AI auto-tagging coupling.** Auto-tagging needs the unmodified source EXIF. It runs on a separate consumer path, not on `ThumbnailReadyEvent`.
+
+---
+
+## License Hygiene
+
+| Component | License | Compatible? |
+|---|---|---|
+| Magick.NET-Q8-x64 (managed wrapper) | Apache 2.0 | Yes |
+| Bundled ImageMagick (native) | ImageMagick (Apache-like) | Yes |
+| libheif (system, runtime-linked) | LGPL | Yes (dynamic link) |
+| PDFium (Phase 16) | BSD 3-Clause + Apache 2.0 | Yes |
+| LibreOffice (Phase 16, out-of-process) | MPL 2.0 | Yes (out-of-process — no static link) |
+
+All compatible with strg's Apache 2.0 license. No GPL dependencies enter the binary.
+
+---
+
+## Re-generation on Algorithm Change
+
+`ThumbnailEntry.GeneratorVersion` is a string field set when the row is written. It is not wired to any auto-regeneration trigger in v1; it exists so a future operator-action ("force regenerate everything older than version X") can target the right rows without scanning blob bytes.
+
+The admin backfill mutation (planned) accepts a candidate predicate. A version-bump regeneration would extend that predicate to `WHERE GeneratorVersion != currentVersion`. Cheap to include now, costly to retrofit later — same logic as audit-row foreign keys: add the column at table-creation time even if unused.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -221,7 +221,8 @@ docs/issues/
     ├── STRG-067 through STRG-074   (WebDAV server)
     ├── STRG-082 through STRG-089   (security, plugin interfaces)
     ├── STRG-200 through STRG-203   (testing infrastructure)
-    └── STRG-300 through STRG-328   (inbox feature: v0.1 pipeline + v0.2 advanced)
+    ├── STRG-300 through STRG-328   (inbox feature: v0.1 pipeline + v0.2 advanced)
+    └── STRG-329 through STRG-344   (Phase 15 thumbnails — images only)
 ```
 
 ### Phase 14: Inbox Feature (v0.2 — advanced conditions + actions)
@@ -237,6 +238,29 @@ docs/issues/
 | STRG-326 | Bulk re-run inbox rules with filter | STRG-308, STRG-311 |
 | STRG-327 | simulateInboxRule dry-run mutation | STRG-306, STRG-302, STRG-320 |
 | STRG-328 | System-provided rule templates | STRG-302, STRG-310 |
+
+### Phase 15: Thumbnails (v0.2 — images only, document formats deferred to Phase 16)
+
+ADR: `docs/architecture/06-thumbnails.md`. Tranche proposal: GitHub issue #52.
+
+| Issue | Title | Depends On |
+|---|---|---|
+| STRG-329 | ThumbnailEntry entity + EF config + migration + repository | STRG-031, STRG-061 |
+| STRG-330 | IThumbnailService + IThumbnailGenerator + registry + MimeSniffer + key builder | STRG-329 |
+| STRG-334 | ThumbnailOptions configuration + startup validation | — |
+| STRG-335 | ADR — image library selection + quota policy + encrypted-drive carve-out | — |
+| STRG-336 | MagickNetImageThumbnailer (Magick.NET-Q8-x64) | STRG-330, STRG-334, STRG-335 |
+| STRG-337 | HEIC/HEIF + EXIF orientation + metadata stripping | STRG-336 |
+| STRG-338 | Resource safeguards — pixel cap + timeout + max-source-size | STRG-334, STRG-336 |
+| STRG-331 | ThumbnailGenerationConsumer + encrypted-drive guard + dead-letter observer | STRG-329, STRG-330, STRG-334, STRG-336, STRG-061 |
+| STRG-332 | ThumbnailCleanupConsumer + extend FileVersionStore.PruneVersionsAsync | STRG-329, STRG-331 |
+| STRG-333 | strg_thumbnails_* metrics extension to StrgMetrics | STRG-331 |
+| STRG-339 | REST GET /files/{fileId}/thumbnail with ETag/304/202-pending | STRG-329, STRG-331 |
+| STRG-341 | ThumbnailReadyEvent + GraphQlSubscriptionPublisher wiring | STRG-331 |
+| STRG-340 | GraphQL FileItem.thumbnail field + DataLoader + thumbnailReady subscription | STRG-339, STRG-341 |
+| STRG-342 | Admin-triggered backfill + ThumbnailGenerationRequestedEvent | STRG-331, STRG-340 |
+| STRG-343 | Integration tests — happy path, bomb, encrypted-drive, prune, extension-point | STRG-336, STRG-337, STRG-338, STRG-339, STRG-340, STRG-342 |
+| STRG-344 | Sandbox hardening follow-up — design-only | — |
 
 ---
 
@@ -259,6 +283,14 @@ docs/issues/
 | STRG-115 | Docker Compose deployment config |
 | STRG-116 | PostgreSQL migration support |
 | STRG-117 | Redis rate limiting (replace in-memory) |
+
+### Phase 16 — Document Thumbnails (reserved by Phase 15 / issue #52)
+
+| Planned ID | Title |
+|---|---|
+| STRG-345 | PDF thumbnails via PDFtoImage / Docnet.Core (PDFium) |
+| STRG-346 | Office thumbnails via LibreOffice headless (opt-in, feature-flagged) |
+| STRG-347 | IEncryptingFileReader extraction — unblocks encrypted-drive thumbnails AND encrypted download |
 
 ### v0.3 Milestone
 

--- a/docs/issues/strg/STRG-329-thumbnail-entry.md
+++ b/docs/issues/strg/STRG-329-thumbnail-entry.md
@@ -1,0 +1,147 @@
+---
+id: STRG-329
+title: ThumbnailEntry entity + EF config + migration + repository
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, storage, ef-core]
+depends_on: [STRG-031, STRG-061]
+blocks: [STRG-330, STRG-331, STRG-332, STRG-339, STRG-340, STRG-342]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-329: ThumbnailEntry entity + EF config + migration + repository
+
+## Summary
+
+Introduce the `ThumbnailEntry` aggregate that tracks every thumbnail blob produced for a `FileVersion`. Bundles the entity, EF Core configuration with a pinned unique-index name, the migration, the constraint-name constants class, and the repository — mirroring the STRG-031 entity-bundle precedent.
+
+## Background / Context
+
+Phase 15 introduces image thumbnail generation as a net-new subsystem (see issue #52 for the full tranche proposal). The consumer (STRG-331) needs a row to write per `(FileVersion, Variant, Format)` triple, with an idempotency key it can rely on under at-least-once redelivery. Decision **D3** in the tranche selected a dedicated `ThumbnailEntry` table over fields-on-`FileVersion` or cache-only — variants × formats × encrypted-drive-carve-out rows make a relational table the only sane shape.
+
+## Technical Specification
+
+### Entity — `src/Strg.Core/Domain/ThumbnailEntry.cs`
+
+```csharp
+public sealed class ThumbnailEntry : TenantedEntity
+{
+    public required Guid FileVersionId { get; init; }
+    public required string Variant { get; init; }       // "thumb" | "small" | "medium"
+    public required string Format { get; init; }        // "webp" | "jpeg"
+    public string StorageKey { get; set; } = "";        // empty until Status=Ready
+    public long SizeBytes { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public ThumbnailStatus Status { get; set; } = ThumbnailStatus.Pending;
+    public string? ErrorReason { get; set; }            // max 256
+    public DateTimeOffset? GeneratedAt { get; set; }
+    public required string GeneratorVersion { get; init; }  // future re-gen trigger
+}
+```
+
+`ThumbnailStatus` lives at `src/Strg.Core/Domain/Thumbnails/ThumbnailStatus.cs`:
+
+```csharp
+public enum ThumbnailStatus { Pending, Ready, Failed, Unsupported }
+```
+
+### Pinned constraint name — `src/Strg.Core/Constants/ThumbnailConstraintNames.cs`
+
+```csharp
+public static class ThumbnailConstraintNames
+{
+    // Authoritative name of the unique index on (FileVersionId, Variant, Format).
+    // Three consumers depend on this string: ThumbnailEntryConfiguration (EF pin via
+    // HasDatabaseName), ThumbnailGenerationConsumer.IsThumbnailUniqueViolation
+    // (equality-match on Npgsql PostgresException.ConstraintName), and MigrationTests
+    // (schema pin). Mirrors the AuditEntryConstraintNames precedent exactly.
+    public const string UniqueIndex = "IX_ThumbnailEntries_FileVersionId_Variant_Format";
+}
+```
+
+### EF configuration — `src/Strg.Infrastructure/Data/Configurations/ThumbnailEntryConfiguration.cs`
+
+- Table name `ThumbnailEntries`.
+- `Variant` and `Format` as `varchar(16)`; `ErrorReason` as `varchar(256)` nullable; `StorageKey` as `varchar(512)`; `GeneratorVersion` as `varchar(32)`.
+- Unique index on `(FileVersionId, Variant, Format)` with `HasDatabaseName(ThumbnailConstraintNames.UniqueIndex)`.
+- Foreign key to `FileVersion` with `OnDelete(DeleteBehavior.Cascade)` so version-row deletion wipes thumbnail rows; blob cleanup is explicit (STRG-332).
+- Index on `Status` to support backfill `WHERE Status NOT IN (Ready, Unsupported)` enumeration without a sequential scan.
+- `Status` mapped via `HasConversion<string>()` for postgres-side readability and easy migration.
+- Soft-delete via the inherited global query filter (`TenantedEntity` base).
+
+### Migration — `src/Strg.Infrastructure/Data/Migrations/YYYYMMDDhhmmss_AddThumbnails.cs`
+
+Generated via `dotnet ef migrations add AddThumbnails --project src/Strg.Infrastructure --startup-project src/Strg.Api`. Manually verify the migration honours the `IX_ThumbnailEntries_FileVersionId_Variant_Format` name pin — EF emits it from `HasDatabaseName`, but the name is pinned so a future rename surfaces as a compile break in the constants class.
+
+### Repository — `src/Strg.Infrastructure/Thumbnails/ThumbnailRepository.cs`
+
+```csharp
+public interface IThumbnailRepository
+{
+    void Add(ThumbnailEntry entry);
+    Task<IReadOnlyList<ThumbnailEntry>> GetByFileVersionAsync(Guid fileVersionId, CancellationToken cancellationToken);
+    Task<ThumbnailEntry?> GetAsync(Guid fileVersionId, string variant, string format, CancellationToken cancellationToken);
+    Task<IReadOnlyList<ThumbnailEntry>> GetByFileAsync(Guid fileId, CancellationToken cancellationToken);
+    void SoftDeleteRange(IEnumerable<ThumbnailEntry> entries);
+}
+```
+
+Per project convention, the repository does NOT call `SaveChangesAsync` — the caller (consumer / endpoint handler) commits.
+
+### DbContext registration — `src/Strg.Infrastructure/Data/StrgDbContext.cs`
+
+Add `public DbSet<ThumbnailEntry> ThumbnailEntries => Set<ThumbnailEntry>();` and `modelBuilder.ApplyConfiguration(new ThumbnailEntryConfiguration());`.
+
+## Acceptance Criteria
+
+- [ ] `ThumbnailEntry` extends `TenantedEntity` with the fields above.
+- [ ] `ThumbnailStatus` enum lives in `Strg.Core` (no NuGet deps introduced).
+- [ ] `ThumbnailConstraintNames.UniqueIndex` is the single source of truth for the index name.
+- [ ] EF configuration pins the index name via `HasDatabaseName(ThumbnailConstraintNames.UniqueIndex)`.
+- [ ] Migration generated and applied to the test database; PostgreSQL + SQLite both build.
+- [ ] Cascade from `FileVersion` deletion to `ThumbnailEntry` rows is in place at the DB level.
+- [ ] `IThumbnailRepository` does not call `SaveChangesAsync`.
+- [ ] Architecture test (`Strg.Architecture.Tests`) confirms `Strg.Core` still has zero NuGet deps after the new files land.
+
+## Test Cases
+
+- **TC-001**: Inserting two `ThumbnailEntry` rows with the same `(FileVersionId, Variant, Format)` triggers `DbUpdateException` whose inner `PostgresException.SqlState == "23505"` and `ConstraintName == ThumbnailConstraintNames.UniqueIndex`.
+- **TC-002**: `MigrationTests.SchemaMatchesModel()` passes after the new migration is added (no model-drift warning).
+- **TC-003**: Soft-deleting the `FileVersion` cascades to its `ThumbnailEntry` rows (DB-level cascade trigger, verified via integration test with EF query post-delete).
+- **TC-004**: `IThumbnailRepository.GetByFileVersionAsync` honours the inherited tenant filter — a row with a different `TenantId` is invisible.
+
+## Implementation Tasks
+
+- [ ] Add `ThumbnailEntry`, `ThumbnailStatus`, `ThumbnailConstraintNames` to `Strg.Core`.
+- [ ] Add `ThumbnailEntryConfiguration` and apply in `StrgDbContext.OnModelCreating`.
+- [ ] Add `DbSet<ThumbnailEntry>` to `StrgDbContext`.
+- [ ] Generate migration `AddThumbnails`; verify constraint name in the generated SQL.
+- [ ] Add `IThumbnailRepository` (Core) + `ThumbnailRepository` (Infrastructure).
+- [ ] Update `MigrationTests` (or equivalent) to cover the new schema.
+- [ ] Architecture test sanity: run `dotnet test tests/Strg.Architecture.Tests`.
+
+## Security Review Checklist
+
+- [ ] `ThumbnailEntry` inherits the tenant filter (no `IgnoreQueryFilters` anywhere in this PR).
+- [ ] `ErrorReason` is bounded at 256 chars to avoid log/DB amplification on adversarial inputs.
+- [ ] `StorageKey` is treated as opaque — never concatenated into paths without `StoragePath.Parse()` (enforced in STRG-330's key builder).
+- [ ] No PII in any field; `GeneratorVersion` is a static identifier, not user input.
+
+## Code Review Checklist
+
+- [ ] No `SaveChangesAsync` calls in the repository.
+- [ ] Constraint name centralized in the constants class — not duplicated as a magic string anywhere.
+- [ ] `Status` HasConversion<string>() in EF config (postgres readability).
+- [ ] Migration tested against both `Database:Provider = sqlite` and `postgres`.
+- [ ] No `Cascade` left on accidental aggregate roots; only `FileVersion → ThumbnailEntry`.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green with concrete evidence (`file:line` or test method).
+- [ ] Migration applied cleanly on a fresh DB and on the integration test fixture.
+- [ ] Architecture tests pass.
+- [ ] No NuGet packages added to `Strg.Core`.

--- a/docs/issues/strg/STRG-330-thumbnail-interfaces.md
+++ b/docs/issues/strg/STRG-330-thumbnail-interfaces.md
@@ -1,0 +1,209 @@
+---
+id: STRG-330
+title: IThumbnailService + IThumbnailGenerator + registry + MimeSniffer + key builder
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, abstractions, core]
+depends_on: [STRG-329]
+blocks: [STRG-331, STRG-336, STRG-339, STRG-340, STRG-342]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-330: IThumbnailService + IThumbnailGenerator + registry + MimeSniffer + key builder
+
+## Summary
+
+Introduce all `Strg.Core` abstractions for thumbnail generation. Bundles four units of work — `IThumbnailService` (orchestrator), `IThumbnailGenerator` (generator contract with self-declaring `CanHandle`), `IThumbnailGeneratorRegistry` (resolve-by-MIME), `MimeSniffer` (zero-dep magic-byte whitelist), and `ThumbnailStorageKeyBuilder` (centralized key scheme). They are co-designed: splitting them forces churn on each side.
+
+## Background / Context
+
+Decision **D11** of issue #52 chose **handler-declared via `IThumbnailGenerator.CanHandle(mimeType, magicBytes)`** so the consumer never branches on MIME — new generators (PDF in STRG-345, Office in STRG-346) plug into the registry without consumer/API/DB changes. Decision **D12** chose **magic-byte sniffing at thumbnail time** because `FileItem.MimeType` is client-provided and untrusted. The registry mirrors `IStorageProviderRegistry` (first registered match wins). The key builder centralizes the `thumbnails/{driveId}/{fileVersionId}/{variant}.{format}` scheme so call sites never concatenate strings — same discipline as the existing `StorageKey` handling in `FileVersionStore`.
+
+## Technical Specification
+
+All types live in `Strg.Core` (zero NuGet deps).
+
+### `IThumbnailGenerator` — `src/Strg.Core/Services/IThumbnailGenerator.cs`
+
+```csharp
+public interface IThumbnailGenerator
+{
+    bool CanHandle(string mimeType, ReadOnlySpan<byte> magicBytes);
+
+    Task<ThumbnailGenerationOutcome> GenerateAsync(
+        Stream source,
+        ThumbnailRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed record ThumbnailRequest(
+    string Variant,
+    int TargetEdgePixels,
+    string TargetFormat,
+    long SourceSizeBytes,
+    string SourceMimeType);
+
+public abstract record ThumbnailGenerationOutcome
+{
+    public sealed record Success(Stream Output, int Width, int Height, string Format)
+        : ThumbnailGenerationOutcome;
+    public sealed record Unsupported(string Reason) : ThumbnailGenerationOutcome;
+    public sealed record SourceCorrupt(string Reason) : ThumbnailGenerationOutcome;
+    public sealed record ResourceLimitExceeded(string Reason) : ThumbnailGenerationOutcome;
+    public sealed record TimedOut(TimeSpan Limit) : ThumbnailGenerationOutcome;
+}
+```
+
+A typed result (sum type) — not exceptions — because each outcome maps to a different `ThumbnailEntry.Status`/`ErrorReason` and metric label.
+
+### `IThumbnailGeneratorRegistry` — `src/Strg.Core/Services/IThumbnailGeneratorRegistry.cs`
+
+```csharp
+public interface IThumbnailGeneratorRegistry
+{
+    IThumbnailGenerator? Resolve(string mimeType, ReadOnlySpan<byte> magicBytes);
+}
+```
+
+First-registered-wins. Implementation lives in Infrastructure (DI-resolves all `IThumbnailGenerator` registrations).
+
+### `IThumbnailService` — `src/Strg.Core/Services/IThumbnailService.cs`
+
+```csharp
+public interface IThumbnailService
+{
+    Task GenerateAllAsync(
+        Guid fileVersionId,
+        Guid driveId,
+        IReadOnlyList<string> variants,
+        CancellationToken cancellationToken);
+}
+```
+
+The orchestrator — the consumer talks to this, not to individual generators. Implementation in Infrastructure (STRG-331 wires the consumer; the service itself is provider-agnostic).
+
+### `ThumbnailVariant` — `src/Strg.Core/Media/ThumbnailVariant.cs`
+
+```csharp
+public static class ThumbnailVariants
+{
+    public const string Thumb = "thumb";
+    public const string Small = "small";
+    public const string Medium = "medium";
+
+    public static int EdgePixelsFor(string variant) => variant switch
+    {
+        Thumb => 256,
+        Small => 512,
+        Medium => 1024,
+        _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown variant"),
+    };
+
+    public static IReadOnlyList<string> All => new[] { Thumb, Small, Medium };
+}
+```
+
+String constants (not enum) so future operator-tunable variants (config-driven) don't force a code change.
+
+### `MimeSniffer` — `src/Strg.Core/Media/MimeSniffer.cs`
+
+```csharp
+public static class MimeSniffer
+{
+    public static string? Detect(ReadOnlySpan<byte> head);
+}
+```
+
+Whitelist (first ~16 bytes), NOT libmagic:
+
+| Format | Signature |
+|---|---|
+| JPEG | `FF D8 FF` |
+| PNG | `89 50 4E 47 0D 0A 1A 0A` |
+| GIF | `47 49 46 38 37 61` / `47 49 46 38 39 61` |
+| WebP | `RIFF`?? `WEBP` (offset 8) |
+| PDF | `25 50 44 46 2D` (`%PDF-`) |
+| HEIC/HEIF | `ftyp` (offset 4) + brand in {`heic`, `heix`, `mif1`, `msf1`, `heim`, `heis`, `hevc`, `hevx`} |
+
+PDF inclusion is intentional — the registry lookup will return `null` (no PDF generator in v1), which writes `Unsupported`. When STRG-345 adds the PDF generator, the sniffer is unchanged.
+
+Returns canonical IANA MIME (`image/jpeg`, `image/png`, `image/gif`, `image/webp`, `application/pdf`, `image/heic`) or `null` for unknown.
+
+Truncated input (less than the format's signature length) returns `null` — handlers must self-check.
+
+### `ThumbnailStorageKeyBuilder` — `src/Strg.Core/Services/ThumbnailStorageKeyBuilder.cs`
+
+```csharp
+public static class ThumbnailStorageKeyBuilder
+{
+    public static string Build(Guid driveId, Guid fileVersionId, string variant, string format);
+}
+```
+
+Returns `thumbnails/{driveId:D}/{fileVersionId:D}/{variant}.{format}`. `{variant}` and `{format}` MUST be from the validated whitelist; the builder asserts. Callers (consumer + endpoint) MUST wrap the result in `StoragePath.Parse()` before hitting `IStorageProvider` — this is documented on the method.
+
+### Domain events — `src/Strg.Core/Events/`
+
+```csharp
+// ThumbnailReadyEvent.cs
+public sealed record ThumbnailReadyEvent(
+    Guid TenantId, Guid FileId, Guid FileVersionId,
+    string Variant, string Format, int Width, int Height) : IDomainEvent;
+
+// ThumbnailGenerationRequestedEvent.cs (backfill — dedicated, not republished FileUploadedEvent)
+public sealed record ThumbnailGenerationRequestedEvent(
+    Guid TenantId, Guid FileId, Guid FileVersionId, Guid DriveId) : IDomainEvent;
+```
+
+The dedicated backfill event — NOT republished `FileUploadedEvent` — avoids double-writing audit entries via `AuditLogConsumer`. The generation consumer (STRG-331) handles both event types by sharing a private orchestration method.
+
+## Acceptance Criteria
+
+- [ ] All interfaces, types, sniffer, key builder, and events live under `Strg.Core` with zero NuGet deps.
+- [ ] `IThumbnailGenerator.CanHandle(string, ReadOnlySpan<byte>)` is the only branching surface for MIME — consumer never `if (mime == ...)`.
+- [ ] `MimeSniffer.Detect` covers JPEG/PNG/GIF/WebP/PDF/HEIC and rejects truncated input.
+- [ ] `ThumbnailStorageKeyBuilder.Build` produces stable, deterministic keys; xml-docs require `StoragePath.Parse()` wrapping at call sites.
+- [ ] `ThumbnailGenerationOutcome` is a closed sum type (sealed records).
+- [ ] No exceptions thrown for expected failure modes (`Unsupported`, `SourceCorrupt`, `ResourceLimitExceeded`, `TimedOut` — typed results).
+
+## Test Cases
+
+- **TC-001**: `MimeSniffer.Detect` returns `image/jpeg` for `[FF, D8, FF, ...]`, `image/png` for the 8-byte PNG signature, `image/webp` for `RIFF????WEBP`, `application/pdf` for `%PDF-`, `image/heic` for `....ftypheic`, and `null` for `[]` (truncated).
+- **TC-002**: `ThumbnailStorageKeyBuilder.Build(d, v, "small", "webp")` returns the canonical scheme; calling with an unknown variant throws.
+- **TC-003**: A test `IThumbnailGeneratorRegistry` registered with two generators returns the first registration whose `CanHandle` matches.
+- **TC-004**: Architecture test confirms `Strg.Core` has no NuGet refs after this PR.
+
+## Implementation Tasks
+
+- [ ] Add `IThumbnailGenerator` + outcome sum type + `ThumbnailRequest`.
+- [ ] Add `IThumbnailGeneratorRegistry`.
+- [ ] Add `IThumbnailService`.
+- [ ] Add `ThumbnailVariants` static class.
+- [ ] Add `MimeSniffer` with the whitelist above.
+- [ ] Add `ThumbnailStorageKeyBuilder`.
+- [ ] Add `ThumbnailReadyEvent` + `ThumbnailGenerationRequestedEvent` under `Strg.Core/Events/`.
+- [ ] Unit tests under `tests/Strg.Core.Tests/Media/MimeSnifferTests.cs` and `tests/Strg.Core.Tests/Thumbnails/`.
+
+## Security Review Checklist
+
+- [ ] `MimeSniffer` is a whitelist — unknown signatures return `null`, never a guess.
+- [ ] `ThumbnailStorageKeyBuilder` asserts variant/format are from the whitelist; never accepts user input directly.
+- [ ] `ThumbnailGenerationRequestedEvent` carries `TenantId` explicitly — consumer reads tenant from payload, not ambient context.
+- [ ] No exception leaks user-controlled bytes; outcome's `Reason` strings are static.
+
+## Code Review Checklist
+
+- [ ] No reflection, no IL emit — pure interfaces and records.
+- [ ] Records are `sealed`.
+- [ ] xml-doc on each public type.
+- [ ] CancellationToken parameter named `cancellationToken` (per CLAUDE.md).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green with concrete evidence.
+- [ ] Unit tests pass: `dotnet test tests/Strg.Core.Tests`.
+- [ ] Architecture tests pass: `dotnet test tests/Strg.Architecture.Tests`.
+- [ ] No NuGet packages added to `Strg.Core`.

--- a/docs/issues/strg/STRG-331-generation-consumer.md
+++ b/docs/issues/strg/STRG-331-generation-consumer.md
@@ -1,0 +1,179 @@
+---
+id: STRG-331
+title: ThumbnailGenerationConsumer + encrypted-drive guard + dead-letter observer
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, masstransit, consumer]
+depends_on: [STRG-329, STRG-330, STRG-334, STRG-336, STRG-061]
+blocks: [STRG-332, STRG-333, STRG-339, STRG-341, STRG-342]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: large
+---
+
+# STRG-331: ThumbnailGenerationConsumer + encrypted-drive guard + dead-letter observer
+
+## Summary
+
+The async consumer that turns a `FileUploadedEvent` (or backfill `ThumbnailGenerationRequestedEvent`) into N `ThumbnailEntry` rows + N blobs in storage. Includes the encrypted-drive carve-out (D17), the SQLSTATE-23505 idempotency mirror of `AuditLogConsumer`, and a `IConsumer<Fault<...>>` dead-letter observer.
+
+## Background / Context
+
+Decision **D1** of issue #52 chose **async** generation — upload latency must not be coupled to image processing. The consumer is the single hand-off from the upload flow's outbox event to the per-variant thumbnail rows. It MUST be idempotent under at-least-once redelivery (the existing MassTransit retry/back-off at `src/Strg.Infrastructure/Messaging/MassTransitExtensions.cs:143-148` is 5× exponential 1→30s before dead-letter — inherited automatically).
+
+Decision **D17** is a carve-out: encrypted drives produce a single `Unsupported{encrypted-drive-not-yet-supported}` row and exit. There is no public `IEncryptingFileReader` today — `ChunkedGcmDecryptStream` is `internal sealed` (`src/Strg.Infrastructure/Storage/Encryption/ChunkedGcmDecryptStream.cs:23`) and used only inside `AesGcmFileWriter`'s self-test. STRG-347 will extract a public read-side decryption abstraction for a future Phase 17 thumbnail update.
+
+## Technical Specification
+
+### File — `src/Strg.Infrastructure/Messaging/Consumers/ThumbnailGenerationConsumer.cs`
+
+```csharp
+public sealed class ThumbnailGenerationConsumer(
+    StrgDbContext db,
+    IThumbnailGeneratorRegistry registry,
+    IStorageProvider storageProvider,
+    IThumbnailRepository repo,
+    IPublishEndpoint bus,
+    IOptions<ThumbnailOptions> options,
+    StrgMetrics metrics,
+    ILogger<ThumbnailGenerationConsumer> logger,
+    TimeProvider clock)
+    : IConsumer<FileUploadedEvent>,
+      IConsumer<ThumbnailGenerationRequestedEvent>
+{
+    public Task Consume(ConsumeContext<FileUploadedEvent> ctx) =>
+        ProcessAsync(ctx.Message.TenantId, ctx.Message.FileId, ctx.CancellationToken);
+
+    public Task Consume(ConsumeContext<ThumbnailGenerationRequestedEvent> ctx) =>
+        ProcessAsync(ctx.Message.TenantId, ctx.Message.FileId, ctx.CancellationToken);
+
+    private async Task ProcessAsync(Guid tenantId, Guid fileId, CancellationToken cancellationToken) { ... }
+}
+```
+
+The two `IConsumer<T>` implementations share a single private `ProcessAsync` so the `FileUploadedEvent` upload flow and the `ThumbnailGenerationRequestedEvent` backfill flow exercise identical idempotency / metrics / retry behavior.
+
+### Algorithm
+
+1. **Tenant scoping** — set `ITenantContext.TenantId = tenantId` from the event payload (consumer scope has empty ambient context per CLAUDE.md).
+2. **Resolve the file's latest `FileVersion`** (`db.FileVersions.AsNoTracking().Where(v => v.FileId == fileId).OrderByDescending(v => v.CreatedAt).FirstOrDefaultAsync`).
+3. **Resolve the drive** (no `IgnoreQueryFilters` — global filter is correct here).
+4. **Encrypted-drive guard** (D17):
+   ```csharp
+   if (drive.EncryptionEnabled)
+   {
+       repo.Add(new ThumbnailEntry {
+           FileVersionId = version.Id, Variant = ThumbnailVariants.Thumb, Format = "webp",
+           Status = ThumbnailStatus.Unsupported,
+           ErrorReason = "encrypted-drive-not-yet-supported",
+           GeneratorVersion = ThumbnailGenerator.Version,
+       });
+       try { await db.SaveChangesAsync(cancellationToken); }
+       catch (DbUpdateException ex) when (IsThumbnailUniqueViolation(ex)) { db.ChangeTracker.Clear(); }
+       metrics.IncrementThumbnailSkipped("encrypted-drive");
+       return;
+   }
+   ```
+   Single row only — variant `thumb`, format `webp` — picked deterministically so re-delivery hits the same idempotency key.
+5. **Source-size cap** (per STRG-338) — `if (version.Size > options.Value.MaxSourceSizeBytes) → Unsupported{too-large} + skip metric`.
+6. **Read first ~64 bytes** for magic-byte sniffing — `await using var head = await storageProvider.ReadAsync(version.StorageKey, 0, cancellationToken)` then `var headBytes = new byte[64]; await head.ReadExactlyAsync(headBytes, ...)` (or however many bytes the file has).
+7. **Sniff** — `MimeSniffer.Detect(headBytes)`. If `null` → `Unsupported{unknown-mime}` + skip metric, return.
+8. **Resolve generator** — `registry.Resolve(sniffedMime, headBytes)`. If `null` → `Unsupported{no-generator}` + skip metric.
+9. **For each variant in `options.Value.Variants`** (independent transaction per variant — failure on variant 2 doesn't roll back variant 1):
+   - Insert `ThumbnailEntry { Status = Pending, ... }` and `SaveChangesAsync`. On `IsThumbnailUniqueViolation` → row already exists from a prior delivery; load the existing row. If `Status == Ready` → return early (no-op). If `Status == Pending` from a stale prior attempt → load and continue.
+   - Open a fresh source stream (`storageProvider.ReadAsync(version.StorageKey, 0, ct)` — generator MAY consume the head bytes from this fresh stream, not the sniffer's).
+   - Call `generator.GenerateAsync(source, request, linkedCt)` where `linkedCt` is `cancellationToken` linked with a `CancellationTokenSource(options.Value.GenerationTimeoutSeconds)`.
+   - On `Success`: `await using var output = result.Output;` → `var key = ThumbnailStorageKeyBuilder.Build(...); var path = StoragePath.Parse(key); await storageProvider.WriteAsync(path.Value, output, ct);` → update entry `Status = Ready, StorageKey = path.Value, Width, Height, SizeBytes, GeneratedAt = clock.GetUtcNow()`. Publish `ThumbnailReadyEvent` to outbox BEFORE `SaveChangesAsync`. `metrics.IncrementThumbnailGenerated(format, variant, "ready")` + `metrics.RecordThumbnailDuration`.
+   - On `Unsupported / SourceCorrupt`: update entry `Status = Unsupported, ErrorReason = reason`. `metrics.IncrementThumbnailSkipped(reason)`.
+   - On `ResourceLimitExceeded`: `Status = Unsupported, ErrorReason = "pixel-cap"`. `metrics.IncrementThumbnailSkipped("pixel-cap")`.
+   - On `TimedOut`: `Status = Failed, ErrorReason = "timeout"`. `metrics.IncrementThumbnailGenerated(format, variant, "timed-out")`.
+
+### Idempotency — `IsThumbnailUniqueViolation`
+
+```csharp
+internal static bool IsThumbnailUniqueViolation(DbUpdateException ex) =>
+    ex.InnerException is PostgresException pg
+    && pg.SqlState == "23505"
+    && pg.ConstraintName == ThumbnailConstraintNames.UniqueIndex;
+```
+
+Equality match (NOT substring) — same triangulation as `AuditLogConsumer.IsEventIdUniqueViolation` at `src/Strg.Infrastructure/Messaging/Consumers/AuditLogConsumer.cs:220-233`. On hit: `db.ChangeTracker.Clear()`, log at debug ("re-delivery, row already present"), return.
+
+### Dead-letter observer
+
+```csharp
+public sealed class ThumbnailGenerationFaultObserver(ILogger<ThumbnailGenerationFaultObserver> logger)
+    : IConsumer<Fault<FileUploadedEvent>>,
+      IConsumer<Fault<ThumbnailGenerationRequestedEvent>>
+{
+    // logs { TenantId, FileId, Exceptions } — NO PII, no MIME, no path
+}
+```
+
+Logged at warn. The fault arrives after the 5× retry exhausts.
+
+### DI registration — `src/Strg.Api/Program.cs`
+
+```csharp
+busCfg.AddConsumer<ThumbnailGenerationConsumer>();
+busCfg.AddConsumer<ThumbnailGenerationFaultObserver>();
+```
+
+Retry/back-off inherited automatically from `MassTransitExtensions.UseStrgConsumerDefaults`.
+
+## Acceptance Criteria
+
+- [ ] Consumer implements both `IConsumer<FileUploadedEvent>` and `IConsumer<ThumbnailGenerationRequestedEvent>` and shares a single private orchestration method.
+- [ ] Encrypted-drive (`drive.EncryptionEnabled == true`) produces exactly one `ThumbnailEntry{Status=Unsupported, ErrorReason="encrypted-drive-not-yet-supported"}` and a `strg_thumbnails_skipped_total{reason=encrypted-drive}` increment.
+- [ ] Re-delivery of the same event produces no additional rows and no additional generation work — idempotency via `IsThumbnailUniqueViolation` (SQLSTATE 23505 + exact `ConstraintName` equality).
+- [ ] Per-variant transaction scope: failure on variant N does not roll back variants 1…N-1.
+- [ ] Generation timeout writes `Status=Failed, ErrorReason="timeout"` and increments `strg_thumbnails_generated_total{status=timed-out}`.
+- [ ] `ThumbnailReadyEvent` is published to the outbox (`IPublishEndpoint`) BEFORE `SaveChangesAsync` so the publish + state change are atomic.
+- [ ] Tenant is read from the event payload, not ambient context.
+- [ ] Source stream and output stream are streamed end-to-end — no `byte[]` buffering.
+- [ ] Dead-letter observer logs `{TenantId, FileId, Exceptions}` only — no MIME, no path, no PII.
+- [ ] All thumbnail keys flow through `StoragePath.Parse()` before reaching `IStorageProvider`.
+
+## Test Cases
+
+- **TC-001**: Upload an encrypted-drive file → publish `FileUploadedEvent` → exactly one `Unsupported{encrypted-drive-not-yet-supported}` row, no blobs, `strg_thumbnails_skipped_total{reason=encrypted-drive}` += 1.
+- **TC-002**: Same event published twice → 1 set of N rows (not 2N); `strg_thumbnails_generated_total` increments N (not 2N).
+- **TC-003**: Generator throws `OperationCanceledException` after timeout → row at `Failed{timeout}`, metric `strg_thumbnails_generated_total{status=timed-out}` += 1, no blob written.
+- **TC-004**: `MimeSniffer.Detect` returns `null` (e.g., `.txt` upload) → `Unsupported{unknown-mime}` rows for every variant.
+- **TC-005**: Variant 2 generator throws unexpected exception → variant 1's `Ready` row is committed; consumer message goes to retry/dead-letter for variant 2.
+- **TC-006**: Backfill `ThumbnailGenerationRequestedEvent` for a file that already has `Ready` rows → no-op (idempotency); no extra audit entry from `AuditLogConsumer` (which only handles `FileUploadedEvent` not the backfill event).
+
+## Implementation Tasks
+
+- [ ] Add `ThumbnailGenerationConsumer` with both `IConsumer` interfaces and the shared private `ProcessAsync`.
+- [ ] Add `IsThumbnailUniqueViolation` mirroring `AuditLogConsumer.IsEventIdUniqueViolation`.
+- [ ] Add `ThumbnailGenerationFaultObserver`.
+- [ ] Register both in `Program.cs`.
+- [ ] Wire `IThumbnailService` (Infrastructure impl) to call into the consumer's logic OR have the consumer call into `IThumbnailService` — choose one and document.
+- [ ] Integration tests under `tests/Strg.Integration.Tests/Thumbnails/ThumbnailGenerationConsumerTests.cs` covering all six test cases.
+
+## Security Review Checklist
+
+- [ ] No `IgnoreQueryFilters()` anywhere in the consumer — tenant filter is in force.
+- [ ] Tenant set from event payload, not ambient context.
+- [ ] Encrypted-drive carve-out cannot be bypassed by a malformed event (tested in TC-001).
+- [ ] User-controlled bytes (sniffed MIME, image content) never flow into log messages or exception text.
+- [ ] Dead-letter log fields are bounded — no `Exception.ToString()` directly when it might contain stack frames with user paths (use `ex.GetType().FullName` + `ex.Message` only).
+- [ ] All paths go through `StoragePath.Parse()` before `IStorageProvider`.
+
+## Code Review Checklist
+
+- [ ] `IsThumbnailUniqueViolation` uses **equality** not `Contains` for `ConstraintName`.
+- [ ] Per-variant transaction scope — explicit `BeginTransactionAsync` / `CommitAsync` if needed to ensure isolation.
+- [ ] `IDomainEvent` published BEFORE `SaveChangesAsync` (outbox semantics).
+- [ ] No `Thread.Sleep`; cancellation linked via `CancellationTokenSource.CreateLinkedTokenSource`.
+- [ ] Streams are `await using`-ed.
+- [ ] No `new HttpClient()` (irrelevant here, but checked).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Integration tests pass.
+- [ ] `MassTransitExtensions` retry config covers the new consumer (5× exponential 1→30s before dead-letter).
+- [ ] Dead-letter fault observer is registered and tested.

--- a/docs/issues/strg/STRG-332-cleanup-consumer.md
+++ b/docs/issues/strg/STRG-332-cleanup-consumer.md
@@ -1,0 +1,172 @@
+---
+id: STRG-332
+title: ThumbnailCleanupConsumer + extend FileVersionStore.PruneVersionsAsync
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, masstransit, cleanup, prune]
+depends_on: [STRG-329, STRG-331]
+blocks: [STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-332: ThumbnailCleanupConsumer + extend FileVersionStore.PruneVersionsAsync
+
+## Summary
+
+Two cleanup paths for thumbnail rows + blobs: (a) `FileDeletedEvent` consumer that soft-deletes thumbnail rows for all versions of the deleted file and best-effort-deletes the blobs; (b) extension of the existing per-version prune loop in `FileVersionStore.PruneVersionsAsync` so that pruning a `FileVersion` also deletes its thumbnail blobs before the row-removal transaction.
+
+## Background / Context
+
+Issue #52's STRG-332 specifies BOTH cleanup paths in one issue. They share a discipline:
+
+- `IStorageProvider.DeleteAsync` is idempotent by contract (`src/Strg.Plugin.Abstractions/Storage/IStorageProvider.cs:66`) — best-effort deletion never throws on missing keys.
+- `ThumbnailEntry` rows have `OnDelete(Cascade)` from `FileVersion` (STRG-329), so DB-level removal happens automatically when a `FileVersion` row is deleted. The cleanup consumer is responsible for **soft-delete** propagation (when a file is soft-deleted but versions remain) and for **blob cleanup**, which the cascade does NOT do.
+- The prune loop at `src/Strg.Infrastructure/Versioning/FileVersionStore.cs:160-169` is the existing per-version atomic scope. We **extend** it — we do not replace it.
+
+## Technical Specification
+
+### File-delete consumer — `src/Strg.Infrastructure/Messaging/Consumers/ThumbnailCleanupConsumer.cs`
+
+```csharp
+public sealed class ThumbnailCleanupConsumer(
+    StrgDbContext db,
+    IStorageProvider storageProvider,
+    IThumbnailRepository repo,
+    ILogger<ThumbnailCleanupConsumer> logger)
+    : IConsumer<FileDeletedEvent>
+{
+    public async Task Consume(ConsumeContext<FileDeletedEvent> ctx)
+    {
+        var thumbnails = await repo.GetByFileAsync(ctx.Message.FileId, ctx.CancellationToken);
+        if (thumbnails.Count == 0) { return; }
+
+        // Best-effort blob delete first — DeleteAsync is idempotent (load-bearing).
+        // Failure here MUST NOT block the soft-delete; we'd rather have an orphan blob
+        // than a stuck cleanup. Operator-visible via metric.
+        foreach (var t in thumbnails.Where(t => t.Status == ThumbnailStatus.Ready))
+        {
+            try
+            {
+                var path = StoragePath.Parse(t.StorageKey);
+                await storageProvider.DeleteAsync(path.Value, ctx.CancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Best-effort thumbnail blob delete failed for {Key}", t.StorageKey);
+            }
+        }
+
+        repo.SoftDeleteRange(thumbnails);
+        await db.SaveChangesAsync(ctx.CancellationToken);
+    }
+}
+```
+
+Idempotent: re-delivery finds the rows already soft-deleted (hidden by global filter), returns no-op.
+
+### Extension to `FileVersionStore.PruneVersionsAsync`
+
+The existing loop at `src/Strg.Infrastructure/Versioning/FileVersionStore.cs:160-169`:
+
+```csharp
+foreach (var version in toPrune)
+{
+    await provider.DeleteAsync(version.StorageKey, cancellationToken).ConfigureAwait(false);
+
+    await using var tx = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+    db.FileVersions.Remove(version);
+    await quotaService.ReleaseAsync(file.CreatedBy, version.Size, cancellationToken).ConfigureAwait(false);
+    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+}
+```
+
+becomes:
+
+```csharp
+foreach (var version in toPrune)
+{
+    await provider.DeleteAsync(version.StorageKey, cancellationToken).ConfigureAwait(false);
+
+    // STRG-332: enumerate thumbnail blobs BEFORE the per-version transaction so a
+    // crash mid-loop leaves the blobs idempotently re-deletable on retry. The
+    // ThumbnailEntry rows themselves cascade away when the FileVersion row is
+    // deleted inside the transaction (STRG-329's OnDelete(Cascade)).
+    var thumbnailKeys = await db.ThumbnailEntries
+        .Where(t => t.FileVersionId == version.Id && t.Status == ThumbnailStatus.Ready)
+        .Select(t => t.StorageKey)
+        .ToListAsync(cancellationToken)
+        .ConfigureAwait(false);
+
+    foreach (var key in thumbnailKeys)
+    {
+        await provider.DeleteAsync(key, cancellationToken).ConfigureAwait(false);
+    }
+
+    await using var tx = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+    db.FileVersions.Remove(version);
+    await quotaService.ReleaseAsync(file.CreatedBy, version.Size, cancellationToken).ConfigureAwait(false);
+    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    await tx.CommitAsync(cancellationToken).ConfigureAwait(false);
+}
+```
+
+The blob delete stays OUTSIDE the per-version transaction (matches the existing pattern for `version.StorageKey`). The `ThumbnailEntry` rows cascade away when the `FileVersion` row is removed inside the transaction.
+
+### Race condition — prune races with generation
+
+If `PruneVersionsAsync` runs while a `ThumbnailGenerationConsumer` is mid-write:
+
+1. Prune deletes the source `FileVersion` blob.
+2. Prune deletes the `FileVersion` row → cascade deletes `ThumbnailEntry` rows.
+3. Generation consumer tries to insert a new `ThumbnailEntry` → FK violation → exception → MassTransit retries.
+4. On retry, generation consumer reads the file (`db.FileVersions.FirstOrDefaultAsync(...)`) and finds nothing (soft-deleted, hidden by filter) → no-op return.
+
+The race is benign — generation either races and lands a row that immediately cascades away, or skips entirely. No orphan blobs (the cascade fires; the new generation's blob is the only at-risk asset, and the per-variant write is the last step before the row update).
+
+## Acceptance Criteria
+
+- [ ] `ThumbnailCleanupConsumer` consumes `FileDeletedEvent`, soft-deletes thumbnail rows, best-effort-deletes blobs, idempotent on re-delivery.
+- [ ] `FileVersionStore.PruneVersionsAsync` enumerates and deletes thumbnail blobs for each pruned version BEFORE the per-version transaction.
+- [ ] Cascade on `FileVersion → ThumbnailEntry` (from STRG-329) handles row removal inside the transaction.
+- [ ] Best-effort blob deletes log warnings on failure but do NOT block the soft-delete or prune.
+- [ ] All thumbnail keys flow through `StoragePath.Parse()` before `IStorageProvider.DeleteAsync`.
+- [ ] No new `IgnoreQueryFilters` calls anywhere in this PR.
+
+## Test Cases
+
+- **TC-001**: Soft-delete a file with 3 thumbnail rows → all 3 rows soft-deleted, 3 blob delete calls fired, consumer succeeds.
+- **TC-002**: Re-deliver `FileDeletedEvent` → consumer finds 0 thumbnails (already soft-deleted) → no-op, no error.
+- **TC-003**: Best-effort blob delete throws (provider error) → consumer logs warning, soft-deletes rows anyway, succeeds.
+- **TC-004**: Upload 4 versions with `keepCount=2` → prune runs → for each of the 2 pruned versions, the 3 thumbnail blobs are deleted via `IStorageProvider.DeleteAsync`, and the cascade removes the rows when the `FileVersion` row is deleted.
+- **TC-005**: Race test (best-effort) — start a generation consumer for a `FileVersion` that is soft-deleted mid-flight; verify generation no-ops gracefully (returns without error after seeing the row hidden).
+
+## Implementation Tasks
+
+- [ ] Add `ThumbnailCleanupConsumer`.
+- [ ] Register in `Program.cs`: `busCfg.AddConsumer<ThumbnailCleanupConsumer>()`.
+- [ ] Modify `FileVersionStore.PruneVersionsAsync` per the diff above.
+- [ ] Integration tests under `tests/Strg.Integration.Tests/Thumbnails/ThumbnailCleanupTests.cs`.
+
+## Security Review Checklist
+
+- [ ] `StoragePath.Parse` wraps every thumbnail key before `IStorageProvider.DeleteAsync`.
+- [ ] Tenant scope: cleanup consumer reads tenant from `FileDeletedEvent.TenantId`.
+- [ ] No `IgnoreQueryFilters` — soft-deleted rows are excluded from `GetByFileAsync` by the global filter (which is the desired idempotency behavior).
+- [ ] Best-effort blob delete failures are logged but never expose user paths in the warning message (`StorageKey` is opaque, but verify it doesn't include user-controlled segments).
+
+## Code Review Checklist
+
+- [ ] Prune-loop change is **additive** — existing transaction scope and retry semantics preserved.
+- [ ] `ConfigureAwait(false)` consistent with the surrounding file's style.
+- [ ] No N+1 — `ThumbnailEntries` query happens once per version (acceptable; alternative is a join, but the surrounding loop is per-version anyway).
+- [ ] Dead-letter behavior: cleanup consumer should NOT dead-letter on best-effort blob errors (the catch makes this safe).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Integration tests pass: TC-001 through TC-005 each have named test methods.
+- [ ] Manually verified: pruned `FileVersion` leaves no orphan thumbnail blobs in `InMemoryStorageProvider` after the test runs.

--- a/docs/issues/strg/STRG-333-metrics.md
+++ b/docs/issues/strg/STRG-333-metrics.md
@@ -1,0 +1,132 @@
+---
+id: STRG-333
+title: strg_thumbnails_* metrics extension to StrgMetrics
+milestone: v0.2
+priority: medium
+status: open
+type: feature
+labels: [thumbnails, phase-15, observability, metrics]
+depends_on: [STRG-331]
+blocks: [STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: small
+---
+
+# STRG-333: strg_thumbnails_* metrics extension to StrgMetrics
+
+## Summary
+
+Extend the existing `StrgMetrics` helper with thumbnail-specific counters, histogram, and an UpDownCounter. No new `Meter` instance — reuses `StrgMetrics.MeterName = "Strg"`.
+
+## Background / Context
+
+Per CLAUDE.md and the STRG-007 precedent, all observability flows through the singleton `StrgMetrics` helper at `src/Strg.Infrastructure/Observability/StrgMetrics.cs:20-47`. `/metrics` is anonymous — no PII, no high-cardinality labels (no `tenantId`, no `userId`, no MIME-from-content).
+
+## Technical Specification
+
+### Additions to `src/Strg.Infrastructure/Observability/StrgMetrics.cs`
+
+```csharp
+// Counters
+public Counter<long> ThumbnailsGeneratedTotal { get; }   // labels: format, variant, status
+public Counter<long> ThumbnailsSkippedTotal { get; }     // labels: reason
+
+// Histogram
+public Histogram<double> ThumbnailsGenerationDurationSeconds { get; }  // labels: format, unit "s"
+
+// UpDownCounter
+public UpDownCounter<long> ThumbnailsInflight { get; }   // no labels
+```
+
+Constructor (additions inside the existing constructor — no new `Meter`):
+
+```csharp
+ThumbnailsGeneratedTotal = _meter.CreateCounter<long>(
+    "strg_thumbnails_generated_total",
+    unit: null,
+    description: "Thumbnail generation outcomes (per variant, per format, per status).");
+
+ThumbnailsSkippedTotal = _meter.CreateCounter<long>(
+    "strg_thumbnails_skipped_total",
+    unit: null,
+    description: "Thumbnail generation skipped (reason: encrypted-drive, too-large, pixel-cap, unknown-mime, no-generator).");
+
+ThumbnailsGenerationDurationSeconds = _meter.CreateHistogram<double>(
+    "strg_thumbnails_generation_duration_seconds",
+    unit: "s",
+    description: "Thumbnail generation wall time, per format.");
+
+ThumbnailsInflight = _meter.CreateUpDownCounter<long>(
+    "strg_thumbnails_inflight",
+    unit: null,
+    description: "Concurrent thumbnail generations in progress.");
+```
+
+### Helper methods
+
+```csharp
+public void IncrementThumbnailGenerated(string format, string variant, string status) =>
+    ThumbnailsGeneratedTotal.Add(1,
+        new KeyValuePair<string, object?>("format", format),
+        new KeyValuePair<string, object?>("variant", variant),
+        new KeyValuePair<string, object?>("status", status));   // "ready" | "timed-out"
+
+public void IncrementThumbnailSkipped(string reason) =>
+    ThumbnailsSkippedTotal.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+public void RecordThumbnailDuration(string format, double seconds) =>
+    ThumbnailsGenerationDurationSeconds.Record(seconds,
+        new KeyValuePair<string, object?>("format", format));
+```
+
+### Label cardinality budget
+
+| Label | Cardinality | Source |
+|---|---|---|
+| `format` | 2 (`webp`, `jpeg` in v1) — bounded | enum-like whitelist |
+| `variant` | 3 (`thumb`, `small`, `medium`) — bounded | `ThumbnailVariants.All` |
+| `status` | 2 (`ready`, `timed-out`) | hard-coded |
+| `reason` | 5 (`encrypted-drive`, `too-large`, `pixel-cap`, `unknown-mime`, `no-generator`) | hard-coded |
+
+Total cross-product is bounded — no PII, no user-derived strings.
+
+## Acceptance Criteria
+
+- [ ] All four instruments are added to `StrgMetrics` using the existing `_meter` field.
+- [ ] No new `Meter` instance — `MeterName = "Strg"` is reused.
+- [ ] Helper methods enforce the label whitelist via parameter types or runtime asserts (the consumer at STRG-331 only passes from a hard-coded set).
+- [ ] Histogram unit is `"s"` (seconds), per OTel semantic conventions.
+- [ ] No tenant/user/file/path labels anywhere.
+
+## Test Cases
+
+- **TC-001**: After a successful generation, `strg_thumbnails_generated_total{format=webp,variant=small,status=ready}` is `1`.
+- **TC-002**: After a 100 MP bomb, `strg_thumbnails_skipped_total{reason=pixel-cap}` is `1`.
+- **TC-003**: Histogram `strg_thumbnails_generation_duration_seconds{format=webp}` records a value in the expected range (>0, <30) for a real test image.
+- **TC-004**: `strg_thumbnails_inflight` increments before generation starts and decrements after (verified via concurrent test).
+- **TC-005**: `/metrics` (anonymous) does NOT emit any tenant/user/file labels for the thumbnail counters.
+
+## Implementation Tasks
+
+- [ ] Extend `StrgMetrics` with the four instruments + helper methods.
+- [ ] Inject `StrgMetrics` into `ThumbnailGenerationConsumer` (already done in STRG-331).
+- [ ] Test under `tests/Strg.Integration.Tests/Thumbnails/ThumbnailMetricsTests.cs` (or fold into the consumer integration tests).
+
+## Security Review Checklist
+
+- [ ] No PII labels. Verified by reading the helper method implementations.
+- [ ] No user-controlled strings as label values — only enum-like whitelisted constants.
+- [ ] `/metrics` remains anonymous post-PR (no auth requirement added accidentally).
+
+## Code Review Checklist
+
+- [ ] Metric names follow `strg_*` convention.
+- [ ] Unit on histogram is `"s"`.
+- [ ] Counter unit is `null` (not `"By"` — these are events, not bytes).
+- [ ] Helper methods are `public` so test code can assert directly.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] `dotnet test` passes.
+- [ ] Manual `/metrics` smoke shows the new instruments after a test upload.

--- a/docs/issues/strg/STRG-334-options.md
+++ b/docs/issues/strg/STRG-334-options.md
@@ -1,0 +1,134 @@
+---
+id: STRG-334
+title: ThumbnailOptions configuration record + startup validation
+milestone: v0.2
+priority: medium
+status: open
+type: feature
+labels: [thumbnails, phase-15, configuration]
+depends_on: []
+blocks: [STRG-331, STRG-336, STRG-338, STRG-342]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: small
+---
+
+# STRG-334: ThumbnailOptions configuration record + startup validation
+
+## Summary
+
+Introduce `ThumbnailOptions` — the strongly-typed config record for the thumbnail subsystem — bound to `Thumbnails:*` configuration with fail-fast startup validation.
+
+## Background / Context
+
+Issue #52 mandates the config gates `Thumbnails:PdfEnabled` / `Thumbnails:OfficeEnabled` exist **from day 1** even though Phase 16 ships the actual generators. Adding them later would force a config-schema migration on operators. Resource-safeguard limits (`MaxSourceSizeBytes`, `MaxPixelArea`, `GenerationTimeoutSeconds`) live in this options record so they can be tuned per deployment without code changes.
+
+## Technical Specification
+
+### Options record — `src/Strg.Infrastructure/Thumbnails/ThumbnailOptions.cs`
+
+```csharp
+public sealed class ThumbnailOptions
+{
+    public const string SectionName = "Thumbnails";
+
+    public bool Enabled { get; init; } = true;
+    public IReadOnlyList<string> Variants { get; init; } = new[] { "thumb", "small", "medium" };
+    public long MaxSourceSizeBytes { get; init; } = 256L * 1024 * 1024;   // 256 MiB
+    public long MaxPixelArea { get; init; } = 100_000_000;                 // 100 MP
+    public int GenerationTimeoutSeconds { get; init; } = 30;
+    public int WebPQuality { get; init; } = 82;
+    public bool PdfEnabled { get; init; } = true;
+    public bool OfficeEnabled { get; init; } = false;
+}
+```
+
+### Validator — `src/Strg.Infrastructure/Thumbnails/ThumbnailOptionsValidator.cs`
+
+```csharp
+internal sealed class ThumbnailOptionsValidator : IValidateOptions<ThumbnailOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ThumbnailOptions options) { ... }
+}
+```
+
+Rules — fail-fast at startup, not first-use:
+
+- `Variants` is non-empty.
+- Every variant in `Variants` is in the `ThumbnailVariants.All` whitelist.
+- `MaxSourceSizeBytes > 0`.
+- `MaxPixelArea > 0`.
+- `GenerationTimeoutSeconds > 0` and `<= 600` (10 min ceiling — anything larger is a misconfiguration).
+- `WebPQuality` in `[1, 100]`.
+
+### Startup wiring — `src/Strg.Api/Program.cs`
+
+```csharp
+builder.Services
+    .AddOptions<ThumbnailOptions>()
+    .Bind(builder.Configuration.GetSection(ThumbnailOptions.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
+builder.Services.AddSingleton<IValidateOptions<ThumbnailOptions>, ThumbnailOptionsValidator>();
+```
+
+`.ValidateOnStart()` ensures invalid config crashes the host at boot, not on first thumbnail generation.
+
+### Default `appsettings.json` block
+
+```json
+{
+  "Thumbnails": {
+    "Enabled": true,
+    "Variants": ["thumb", "small", "medium"],
+    "MaxSourceSizeBytes": 268435456,
+    "MaxPixelArea": 100000000,
+    "GenerationTimeoutSeconds": 30,
+    "WebPQuality": 82,
+    "PdfEnabled": true,
+    "OfficeEnabled": false
+  }
+}
+```
+
+## Acceptance Criteria
+
+- [ ] `ThumbnailOptions` exists with the fields and defaults above.
+- [ ] `ThumbnailOptionsValidator` enforces all six rules; each invalid case produces a distinct `ValidateOptionsResult.Fail` with a human-readable message naming the offending field.
+- [ ] `.ValidateOnStart()` is in `Program.cs` — bad config crashes at boot.
+- [ ] `appsettings.json` ships the defaults so operators see the schema.
+- [ ] `PdfEnabled` and `OfficeEnabled` both exist in v1 (no Phase-16 schema migration needed).
+
+## Test Cases
+
+- **TC-001**: Empty `Variants` → validator returns `Fail`.
+- **TC-002**: `Variants = ["enormous"]` (not in whitelist) → `Fail` with the bad value in the message.
+- **TC-003**: `GenerationTimeoutSeconds = 0` → `Fail`; `= 601` → `Fail`; `= 30` → `Success`.
+- **TC-004**: `WebPQuality = 0` → `Fail`; `= 101` → `Fail`; `= 82` → `Success`.
+- **TC-005**: Integration test boots with default config and the host starts (no validation failure).
+
+## Implementation Tasks
+
+- [ ] Add `ThumbnailOptions`.
+- [ ] Add `ThumbnailOptionsValidator`.
+- [ ] Wire `.AddOptions<>().Bind().ValidateOnStart()` in `Program.cs`.
+- [ ] Add defaults to `appsettings.json` and `appsettings.Development.json`.
+- [ ] Unit tests for the validator under `tests/Strg.Api.Tests/Thumbnails/`.
+
+## Security Review Checklist
+
+- [ ] No secrets in `ThumbnailOptions` (provider credentials live elsewhere).
+- [ ] `MaxSourceSizeBytes` cannot be set negative (validator catches it).
+- [ ] Defaults prevent unbounded resource consumption (256 MiB / 100 MP / 30 s — all explicit).
+
+## Code Review Checklist
+
+- [ ] `init`-only properties (immutable after binding).
+- [ ] No magic-string section names — use `ThumbnailOptions.SectionName`.
+- [ ] No reliance on environment variables for options not in this record.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] `dotnet test tests/Strg.Api.Tests` passes.
+- [ ] Host fails to start on invalid config; documented with a representative error message.

--- a/docs/issues/strg/STRG-335-adr-image-library.md
+++ b/docs/issues/strg/STRG-335-adr-image-library.md
@@ -1,0 +1,124 @@
+---
+id: STRG-335
+title: ADR — image library selection + quota policy + encrypted-drive carve-out
+milestone: v0.2
+priority: medium
+status: open
+type: docs
+labels: [thumbnails, phase-15, adr, architecture]
+depends_on: []
+blocks: [STRG-336]
+assigned_agent_type: feature-dev:code-explorer
+estimated_complexity: small
+---
+
+# STRG-335: ADR — image library selection + quota policy + encrypted-drive carve-out
+
+## Summary
+
+Author the architecture decision record at `docs/architecture/06-thumbnails.md` (NOT `05-` — `05-deployment.md` exists). Captures decisions D1–D17 from issue #52 with rationale durable enough to survive contributor churn.
+
+## Background / Context
+
+Issue #52 made 17 binding decisions (D1–D17) about thumbnail generation. These decisions need a durable home so future engineers don't re-litigate them. Particular pressure points: image-library choice (D5 — ImageSharp's license change is a ship-stopper), encrypted-drive carve-out (D17 — requires STRG-347 to lift), and the Phase 16 extension contract.
+
+## Technical Specification
+
+### File — `docs/architecture/06-thumbnails.md`
+
+YAML frontmatter (mirrors `04-event-system.md`):
+
+```yaml
+---
+title: "Thumbnail Generation"
+tags: [architecture, thumbnails, plugins, phase-15]
+status: active
+created: 2026-05-01
+updated: 2026-05-01
+---
+```
+
+H1 + H2 sections only (no H3 per existing ADR convention). Use `---` between major sections. Include code blocks with language hints. Use markdown tables for the decision matrix.
+
+### Required sections
+
+1. **Design** — async generation, blob storage in same provider, dedicated `ThumbnailEntry` entity, encryption-inheritance from drive posture.
+2. **Decisions** — verbatim D1…D17 table from issue #52 (option / chosen / why) — this is the canonical reference.
+3. **Image Library Selection (D5)** — Magick.NET (Apache 2.0) vs NetVips vs SkiaSharp vs ImageSharp; capture the ImageSharp license-change ship-stopper, the Magick.NET-Q8-x64 native-libheif Docker-base-image consequence (STRG-337), and the `IImageThumbnailer` indirection that keeps the door open for swap.
+4. **Quota Policy (D16)** — operator absorbs thumbnail bytes; parallels `FileVersion.BlobSizeBytes` encryption-overhead precedent. Documented so v0.2 quota work isn't reopened.
+5. **Encrypted-Drive Carve-out (D17)** — explain why `IEncryptingFileReader` doesn't exist today (`ChunkedGcmDecryptStream` is `internal sealed` in `AesGcmFileWriter`'s self-test only). Document the consumer's check (`drive.EncryptionEnabled` → `Unsupported{encrypted-drive-not-yet-supported}`). Forward-pointer to STRG-347.
+6. **Extension Map (Phase 16 readiness)** — table of extension points the v1 architecture must hit so PDF/Office land additively:
+
+   | Extension point | Where | What changes when PDF (STRG-345) lands |
+   |---|---|---|
+   | `IThumbnailGenerator.CanHandle` | Core interface | new generator self-declares `application/pdf`; consumer untouched |
+   | `MimeSniffer` whitelist | Core | `%PDF-` already covered; no change |
+   | `ThumbnailStorageKeyBuilder` | Core | `Format` parameterizes; no change |
+   | `ThumbnailEntry.Format` | Core entity | `Format` is a string column; no schema change |
+   | `IConsumer<ThumbnailGenerationRequestedEvent>` | backfill | same event covers PDF; no change |
+   | `Thumbnails:PdfEnabled` config | options | already in `ThumbnailOptions`; flips on |
+
+7. **Event Flow** — table mirroring `04-event-system.md:76`:
+
+   | Event | Handler | Action |
+   |---|---|---|
+   | `FileUploadedEvent` | `ThumbnailGenerationConsumer` | Generate per-variant thumbnails |
+   | `ThumbnailGenerationRequestedEvent` | `ThumbnailGenerationConsumer` | Backfill (admin-triggered) |
+   | `FileDeletedEvent` | `ThumbnailCleanupConsumer` | Soft-delete rows + best-effort blob delete |
+   | `ThumbnailReadyEvent` | `GraphQlSubscriptionPublisher` | Push to `thumbnailReady(fileId)` subscribers |
+
+8. **Resource Safeguards** — pixel-area cap (header probe BEFORE decode), per-generation timeout via `CancellationTokenSource`, source-size cap (file-size probe). In-process for v1; STRG-344 documents process-isolation follow-up.
+
+9. **Out of Scope (Phase 15)** — RAW formats, SVG input, animated thumbnails (first-frame only), generic fallback icons (frontend), AI auto-tagging ordering coupling.
+
+10. **License Hygiene** — Magick.NET Apache 2.0; bundled ImageMagick Apache-like; PDFium MIT/BSD (Phase 16); LibreOffice MPL (Phase 16, opt-in). All compatible with the project's Apache 2.0 license.
+
+11. **Re-generation on algorithm change** — `ThumbnailEntry.GeneratorVersion` field; not wired in v1 but cheap to include now.
+
+### Cross-reference style
+
+Per existing ADR convention (`01-system-overview.md` … `05-deployment.md`):
+
+- No internal-doc cross-links (each ADR is self-contained).
+- External links allowed (e.g., Magick.NET GitHub URL, libheif page).
+- No `STRG-xxx` issue citations inline (issue numbers belong in the issue tracker, not in architecture).
+
+## Acceptance Criteria
+
+- [ ] `docs/architecture/06-thumbnails.md` exists with the YAML frontmatter above.
+- [ ] All 11 sections above are present.
+- [ ] D1–D17 decision table is verbatim from issue #52.
+- [ ] D5 (image library), D16 (quota policy), and D17 (encrypted-drive) each have a dedicated section with rationale.
+- [ ] Phase 16 extension-map table is present.
+- [ ] Event-flow table mirrors `04-event-system.md:76`.
+- [ ] No internal-doc cross-links (matches existing ADR style).
+- [ ] No STRG-xxx citations inline (architecture documents are issue-tracker-agnostic).
+
+## Test Cases
+
+- **TC-001**: Markdown lint — file renders correctly in Obsidian (manual check).
+- **TC-002**: A new contributor reading only the ADR can answer: "why Magick.NET and not ImageSharp", "do thumbnails count against user quota", and "why don't encrypted drives get thumbnails in v1" — without follow-up questions.
+
+## Implementation Tasks
+
+- [ ] Author `docs/architecture/06-thumbnails.md` per the spec above.
+- [ ] Verify the file renders via Obsidian (vault root is `docs/`).
+- [ ] Confirm the file does not collide with existing 05-* (it shouldn't — 05 is `05-deployment.md`, 06 is free).
+
+## Security Review Checklist
+
+- [ ] No secrets, no internal infra details (e.g., specific S3 buckets, credentials).
+- [ ] License-hygiene section is accurate (Apache 2.0, MIT/BSD, MPL — verified).
+- [ ] Encrypted-drive section does NOT publish exploitable detail about the encryption-at-rest envelope format beyond what's already in `02-storage-abstraction.md`.
+
+## Code Review Checklist
+
+- [ ] Frontmatter keys match other ADRs (`title`, `tags`, `status`, `created`, `updated`).
+- [ ] H1 title matches frontmatter title.
+- [ ] H2-only section structure (no H3).
+- [ ] Code blocks have language hints (`csharp`, `json`, `yaml`).
+
+## Definition of Done
+
+- [ ] ADR published at `docs/architecture/06-thumbnails.md`.
+- [ ] Reviewed for accuracy against the actual code shape (post-implementation pass — schedule for after STRG-336).

--- a/docs/issues/strg/STRG-336-magicknet-image-thumbnailer.md
+++ b/docs/issues/strg/STRG-336-magicknet-image-thumbnailer.md
@@ -1,0 +1,211 @@
+---
+id: STRG-336
+title: MagickNetImageThumbnailer — IThumbnailGenerator implementation for images
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, image-processing, magick-net]
+depends_on: [STRG-330, STRG-334, STRG-335]
+blocks: [STRG-337, STRG-338, STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: large
+---
+
+# STRG-336: MagickNetImageThumbnailer — IThumbnailGenerator implementation for images
+
+## Summary
+
+Implement the JPEG/PNG/WebP/GIF/BMP/TIFF image thumbnailer using `Magick.NET-Q8-x64` (Apache 2.0). Outputs WebP at the configured quality (default 82). Letterbox-to-fit on white. Streaming end-to-end — no full-buffer in memory. Resource safeguards (pixel cap + timeout + max-source-size) integrated.
+
+## Background / Context
+
+Decision **D5** (issue #52, ADR STRG-335) selected Magick.NET as the v1 image library:
+- Apache 2.0 license — compatible with strg's license. ImageSharp's license change was the ship-stopper.
+- `Magick.NET-Q8-x64` includes native libheif for HEIC support (STRG-337 builds on this).
+- `MagickImageInfo` allows pixel-area probes BEFORE full decode — load-bearing for the bomb defence.
+
+The thumbnailer sits behind `IThumbnailGenerator` so the consumer never branches on MIME and the choice stays swappable.
+
+## Technical Specification
+
+### Project reference
+
+Add to `src/Strg.Infrastructure/Strg.Infrastructure.csproj`:
+
+```xml
+<PackageReference Include="Magick.NET-Q8-x64" Version="14.*" />
+```
+
+(Q8 sufficient for thumbnails; Q16 doubles memory for no perceptual gain at 256/512/1024 px.)
+
+### File — `src/Strg.Infrastructure/Thumbnails/Generators/MagickNetImageThumbnailer.cs`
+
+```csharp
+public sealed class MagickNetImageThumbnailer(
+    IOptions<ThumbnailOptions> options,
+    StrgMetrics metrics,
+    TimeProvider clock,
+    ILogger<MagickNetImageThumbnailer> logger)
+    : IThumbnailGenerator
+{
+    private static readonly HashSet<string> SupportedMimes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg", "image/png", "image/webp",
+        "image/gif", "image/bmp", "image/tiff",
+        // HEIC handled in STRG-337 — same generator
+    };
+
+    public bool CanHandle(string mimeType, ReadOnlySpan<byte> magicBytes) =>
+        SupportedMimes.Contains(mimeType);
+
+    public async Task<ThumbnailGenerationOutcome> GenerateAsync(
+        Stream source,
+        ThumbnailRequest request,
+        CancellationToken cancellationToken) { ... }
+}
+```
+
+### Algorithm — `GenerateAsync`
+
+```csharp
+metrics.ThumbnailsInflight.Add(1);
+var sw = Stopwatch.StartNew();
+try
+{
+    using var timeoutCts = new CancellationTokenSource(
+        TimeSpan.FromSeconds(options.Value.GenerationTimeoutSeconds));
+    using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+    // 1. Probe header BEFORE full decode (D14 — pixel-cap pre-check).
+    //    MagickImageInfo reads only the header; cheap.
+    var probeBuffer = new MemoryStream();
+    var probeBytes = Math.Min(64 * 1024, request.SourceSizeBytes);  // 64 KiB header probe
+    await CopyHeadAsync(source, probeBuffer, probeBytes, linked.Token);
+    probeBuffer.Position = 0;
+
+    MagickImageInfo info;
+    try { info = new MagickImageInfo(probeBuffer); }
+    catch (MagickException ex)
+    {
+        return new ThumbnailGenerationOutcome.SourceCorrupt($"header-parse: {ex.GetType().Name}");
+    }
+
+    var pixelArea = (long)info.Width * info.Height;
+    if (pixelArea > options.Value.MaxPixelArea)
+    {
+        return new ThumbnailGenerationOutcome.ResourceLimitExceeded(
+            $"pixel-cap ({pixelArea} > {options.Value.MaxPixelArea})");
+    }
+
+    // 2. Rewind: probeBuffer holds the first N bytes; rest of `source` still has the tail.
+    //    Concatenate them so MagickImage gets the full file.
+    probeBuffer.Position = 0;
+    using var concatenated = new ConcatenatingStream(probeBuffer, source);
+    using var image = new MagickImage();
+    await Task.Run(() => image.Read(concatenated), linked.Token);
+
+    // 3. EXIF auto-orient + resize + strip metadata (full sequence in STRG-337).
+    image.AutoOrient();
+    image.Resize(new MagickGeometry((uint)request.TargetEdgePixels, (uint)request.TargetEdgePixels)
+    {
+        Greater = true,                    // shrink only, never enlarge
+        IgnoreAspectRatio = false,
+    });
+
+    // 4. Letterbox to a square canvas with white background (D10).
+    image.Extent(
+        new MagickGeometry((uint)request.TargetEdgePixels, (uint)request.TargetEdgePixels)
+        {
+            X = 0, Y = 0,
+        },
+        Gravity.Center,
+        new MagickColor("#ffffff"));
+
+    image.Strip();                          // remove EXIF/XMP/IPTC (privacy — STRG-337)
+    image.Format = MagickFormat.WebP;
+    image.Quality = (uint)options.Value.WebPQuality;
+
+    var output = new MemoryStream();
+    await Task.Run(() => image.Write(output), linked.Token);
+    output.Position = 0;
+
+    return new ThumbnailGenerationOutcome.Success(
+        output, (int)image.Width, (int)image.Height, "webp");
+}
+catch (OperationCanceledException) when (timeoutFired)
+{
+    return new ThumbnailGenerationOutcome.TimedOut(
+        TimeSpan.FromSeconds(options.Value.GenerationTimeoutSeconds));
+}
+catch (MagickException ex)
+{
+    return new ThumbnailGenerationOutcome.SourceCorrupt($"decode: {ex.GetType().Name}");
+}
+finally
+{
+    metrics.ThumbnailsInflight.Add(-1);
+    metrics.RecordThumbnailDuration("webp", sw.Elapsed.TotalSeconds);
+}
+```
+
+### `ConcatenatingStream` helper
+
+A small `Strg.Infrastructure/Internal/ConcatenatingStream.cs` that reads from stream A then stream B without buffering both fully. Read-only, no seek required by Magick.NET's `Read(Stream)`.
+
+### `MemoryStream` for output
+
+Acceptable for v1 — output thumbnails are bounded by `WebPQuality * area` (typically <500 KiB at 1024 px). The cost is dwarfed by the source image's decode buffer. Future optimization could pipe through `IStorageProvider.WriteAsync` directly, but the current `IStorageProvider` contract takes a `Stream`, which a `MemoryStream` satisfies.
+
+## Acceptance Criteria
+
+- [ ] `Magick.NET-Q8-x64` package added; `Strg.Architecture.Tests` confirms it lives in `Strg.Infrastructure`, NOT `Strg.Core`.
+- [ ] `CanHandle` returns true for `image/jpeg`, `image/png`, `image/webp`, `image/gif`, `image/bmp`, `image/tiff`.
+- [ ] Output is WebP at the configured quality.
+- [ ] Letterbox to a square canvas on white background.
+- [ ] EXIF/XMP/IPTC stripped from output (verify via output-image inspection in test).
+- [ ] Pixel-area probe happens BEFORE full decode (`MagickImageInfo` on the first 64 KiB of the stream).
+- [ ] Pixel-cap exceeded → `ResourceLimitExceeded` returned, no decode performed.
+- [ ] Generation timeout → `TimedOut` returned (typed result, not an exception leaking out).
+- [ ] Streaming end-to-end except for the bounded-size output `MemoryStream`.
+- [ ] No `Thread.Sleep`, no `byte[] = await stream.ReadAllBytes()`.
+
+## Test Cases
+
+- **TC-001**: 600×400 JPEG → output is square 256×256 (or 512/1024 per variant), WebP, letterboxed white.
+- **TC-002**: 100 MP PNG bomb header → `ResourceLimitExceeded("pixel-cap ...")` returned WITHOUT decoding the body.
+- **TC-003**: Corrupt JPEG (truncated body) → `SourceCorrupt(...)` returned, not an exception bubbling up.
+- **TC-004**: 1×1 transparent PNG → `Success(...)` with white background visible (transparency flattened).
+- **TC-005**: Animated GIF (3 frames) → first frame only, `Success(...)`.
+- **TC-006**: TIFF with embedded EXIF → output WebP has no EXIF/XMP/IPTC chunks (verified by re-decoding output and checking metadata).
+
+## Implementation Tasks
+
+- [ ] Add `Magick.NET-Q8-x64` package reference.
+- [ ] Implement `MagickNetImageThumbnailer`.
+- [ ] Implement `ConcatenatingStream` helper (or use an existing one if `Strg.Infrastructure` has one).
+- [ ] Register in `Program.cs`: `services.AddSingleton<IThumbnailGenerator, MagickNetImageThumbnailer>()`.
+- [ ] Unit/integration tests under `tests/Strg.Integration.Tests/Thumbnails/ImageGeneratorTests.cs`.
+
+## Security Review Checklist
+
+- [ ] Pixel-cap check uses `MagickImageInfo` (header-only probe) BEFORE decode — bomb-resistant.
+- [ ] Output `Strip()` removes EXIF/XMP/IPTC including GPS / camera serial / timestamps (privacy).
+- [ ] Generator runs in `Task.Run` with a linked CTS — caller cancellation AND timeout both honored.
+- [ ] No `MagickImage.Read(string path)` — always `Read(Stream)` so no path injection vector.
+- [ ] `MagickException.Message` is NOT exposed to callers — only `ex.GetType().Name` reaches the typed result.
+- [ ] No `MagickReadSettings.Density` from user input (would allow PDF rasterization at attacker-chosen DPI; not relevant here since this is the IMAGE generator, but verify).
+
+## Code Review Checklist
+
+- [ ] `using` for every `IDisposable` (`MagickImage`, `MemoryStream`, `CancellationTokenSource`).
+- [ ] Output `MemoryStream` ownership transferred to the caller (consumer owns disposal via `await using` in STRG-331).
+- [ ] No `dynamic`, no `unsafe`.
+- [ ] CancellationToken parameter named `cancellationToken`.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Architecture test (`Strg.Architecture.Tests`) confirms Magick.NET is NOT referenced from `Strg.Core`.
+- [ ] Test image fixtures (small PNG, JPEG, animated GIF, TIFF) present under `tests/Strg.Integration.Tests/Thumbnails/Fixtures/`.
+- [ ] Linux-x64 + Linux-arm64 verified (Magick.NET-Q8-x64 has separate native bundles — confirm Docker base image carries libheif/libwebp).

--- a/docs/issues/strg/STRG-337-heic-exif.md
+++ b/docs/issues/strg/STRG-337-heic-exif.md
@@ -1,0 +1,147 @@
+---
+id: STRG-337
+title: HEIC/HEIF + EXIF orientation + metadata stripping
+milestone: v0.2
+priority: medium
+status: open
+type: feature
+labels: [thumbnails, phase-15, heic, exif, privacy]
+depends_on: [STRG-336]
+blocks: [STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-337: HEIC/HEIF + EXIF orientation + metadata stripping
+
+## Summary
+
+Extend `MagickNetImageThumbnailer` to support HEIC/HEIF input, apply EXIF orientation BEFORE resize, and strip EXIF/XMP/IPTC from the output (privacy: GPS, camera serial, timestamps).
+
+## Background / Context
+
+Issue #52's STRG-337 bundles three concerns that are tightly coupled:
+
+1. **HEIC support** — modern iOS default for camera output. Magick.NET-Q8-x64 ships with native libheif; no extra package, but the Docker base image must carry the libheif system library.
+2. **EXIF orientation** — JPEG/HEIC frequently carry an `Orientation` tag (1–8). If we resize WITHOUT first auto-orienting, a portrait phone photo lands upside-down or sideways at the thumbnail size. The fix is `image.AutoOrient()` BEFORE `Resize()`.
+3. **Metadata stripping** — EXIF carries GPS coordinates, camera serial numbers, and timestamps. Embedding any of these into a thumbnail that's served to share-link recipients is a serious privacy leak. Strip via `image.Strip()` BEFORE writing the output.
+
+These concerns are bundled because they all live in the same `GenerateAsync` flow, and the test fixtures overlap (orientation-tagged JPEG + GPS-tagged HEIC + EXIF-rich TIFF).
+
+## Technical Specification
+
+### HEIC support — STRG-336 update
+
+In `MagickNetImageThumbnailer.SupportedMimes`:
+
+```csharp
+private static readonly HashSet<string> SupportedMimes = new(StringComparer.OrdinalIgnoreCase)
+{
+    "image/jpeg", "image/png", "image/webp",
+    "image/gif", "image/bmp", "image/tiff",
+    "image/heic", "image/heif",                // STRG-337
+};
+```
+
+`MimeSniffer` already detects HEIC via the `ftyp` brand list (STRG-330).
+
+### Docker base-image consequence
+
+The Docker base image (defined in `Dockerfile`) MUST install:
+
+```dockerfile
+RUN apt-get update && apt-get install -y \
+    libheif1 libheif-plugin-aomdec libheif-plugin-libde265 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+(Or equivalent for Alpine if the project uses a slim base.)
+
+If libheif is missing at runtime, Magick.NET HEIC reads throw `MagickMissingDelegateErrorException`. The thumbnailer's outer `catch (MagickException)` already maps this to `SourceCorrupt(...)`, so the failure mode is graceful — but the operator-facing log MUST surface the missing-delegate hint clearly.
+
+### Orientation — order of operations matters
+
+```csharp
+image.Read(concatenated);
+
+// 1. AutoOrient FIRST — must run before any geometry transform.
+image.AutoOrient();          // applies the EXIF Orientation tag, rotates pixels, sets tag to 1.
+
+// 2. Resize the orientation-corrected pixels.
+image.Resize(new MagickGeometry(...) { Greater = true, IgnoreAspectRatio = false });
+
+// 3. Letterbox.
+image.Extent(...);
+
+// 4. Strip metadata BEFORE write (so the orientation correction we just applied doesn't get
+//    "undone" by a leftover Orientation tag in some viewer's interpretation).
+image.Strip();
+
+// 5. Write.
+image.Format = MagickFormat.WebP;
+image.Quality = ...;
+image.Write(output);
+```
+
+### Metadata stripping — what's removed
+
+`image.Strip()` removes:
+
+- EXIF (GPS, camera serial, timestamps, exposure, lens info)
+- XMP (any embedded metadata)
+- IPTC (caption, copyright, keywords)
+- ICC profiles (color management)
+
+For the THUMBNAIL output, dropping the ICC profile is acceptable — viewers default to sRGB which is what we resize into anyway. For the SOURCE file, we never modify it; this strip is on the in-memory thumbnail copy only.
+
+### What we do NOT do
+
+**We do not extract EXIF for AI auto-tagging here.** That's a separate concern (issue IF-01, future). AI auto-tagging will run on a different consumer path that reads the unmodified source — it does NOT depend on the thumbnail subsystem and MUST NOT inherit our `Strip()` discipline.
+
+## Acceptance Criteria
+
+- [ ] `image/heic` and `image/heif` added to `SupportedMimes`.
+- [ ] HEIC input produces a valid WebP thumbnail.
+- [ ] `image.AutoOrient()` is called BEFORE `Resize()` and `Extent()`.
+- [ ] `image.Strip()` is called BEFORE `Write()`.
+- [ ] Output WebP has no EXIF, XMP, IPTC, or ICC chunks.
+- [ ] Missing-delegate error (libheif unavailable) maps cleanly to `SourceCorrupt(...)` — does not crash.
+- [ ] `Dockerfile` (if present) installs libheif and its plugins.
+
+## Test Cases
+
+- **TC-001**: Portrait-orientation JPEG (EXIF Orientation = 6, "rotate 90 CW") → output is correctly rotated; verify by content inspection (top-of-image pixel is in the expected position).
+- **TC-002**: HEIC sample with GPS coordinates → output WebP has no EXIF chunk (re-decode and assert).
+- **TC-003**: TIFF with full EXIF + IPTC + XMP → output WebP has none of these chunks.
+- **TC-004**: HEIC on a system without libheif → `SourceCorrupt(...)` returned, no crash, error logged with hint text "libheif missing or HEIC delegate not available".
+- **TC-005**: 24-bit RGB JPEG with embedded ICC profile → output renders correctly under sRGB (verify by visual diff against a reference).
+
+## Implementation Tasks
+
+- [ ] Update `SupportedMimes` to include HEIC/HEIF.
+- [ ] Confirm `AutoOrient()` is invoked before `Resize()`/`Extent()` (STRG-336 already calls it; verify ordering).
+- [ ] Confirm `Strip()` is invoked before `Write()`.
+- [ ] Update `Dockerfile` to install libheif + plugins.
+- [ ] Add test fixtures: portrait-orientation JPEG (EXIF=6), HEIC with GPS, EXIF-rich TIFF.
+- [ ] Tests under `tests/Strg.Integration.Tests/Thumbnails/ImageGeneratorTests.cs`.
+
+## Security Review Checklist
+
+- [ ] `Strip()` runs unconditionally — no flag that lets EXIF survive into thumbnails.
+- [ ] Missing-delegate logging does NOT leak file content or paths.
+- [ ] HEIC processing is bounded by the same pixel-cap and timeout as other formats (STRG-338 — same `GenerateAsync` path).
+- [ ] No re-encoding the source file's metadata into the thumbnail (re-orient changes pixels, not metadata).
+- [ ] AI auto-tagging path (future) is documented as needing the unmodified source — this issue does NOT change that.
+
+## Code Review Checklist
+
+- [ ] `AutoOrient()` is BEFORE `Resize()` (test TC-001 catches this).
+- [ ] `Strip()` is BEFORE `Write()`.
+- [ ] No conditional metadata preservation.
+- [ ] Docker base image documentation updated (if `Dockerfile` is present in the repo at this point).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Test fixtures committed under `tests/Strg.Integration.Tests/Thumbnails/Fixtures/`.
+- [ ] HEIC support verified on Linux x64 in CI (or documented as a known gap if CI base image lacks libheif).

--- a/docs/issues/strg/STRG-338-safeguards.md
+++ b/docs/issues/strg/STRG-338-safeguards.md
@@ -1,0 +1,134 @@
+---
+id: STRG-338
+title: Resource safeguards — pixel cap + timeout + max-source-size
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, safeguards, security]
+depends_on: [STRG-334, STRG-336]
+blocks: [STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: small
+---
+
+# STRG-338: Resource safeguards — pixel cap + timeout + max-source-size
+
+## Summary
+
+Three independent pre/in-flight checks that defend the thumbnail subsystem against decompression bombs, runaway generators, and oversized inputs. All three are gated by `ThumbnailOptions` (STRG-334).
+
+## Background / Context
+
+Decision **D14** of issue #52 chose **pixel-area cap + timeout + max-source-size**, in-process for v1, with sandbox process-isolation deferred to STRG-344. The three checks are layered:
+
+1. **Source-size cap** (cheapest) — `FileVersion.Size > MaxSourceSizeBytes`. Rejects before any I/O.
+2. **Pixel-area cap** — `MagickImageInfo` header probe. Rejects after a 64 KiB read but before full decode.
+3. **Timeout** — `CancellationTokenSource(GenerationTimeoutSeconds)` linked with the consumer's CT. Rejects whatever's still running.
+
+## Technical Specification
+
+### Source-size cap — in `ThumbnailGenerationConsumer` (STRG-331)
+
+```csharp
+if (version.Size > options.Value.MaxSourceSizeBytes)
+{
+    foreach (var variant in options.Value.Variants)
+    {
+        repo.Add(new ThumbnailEntry {
+            FileVersionId = version.Id, Variant = variant, Format = "webp",
+            Status = ThumbnailStatus.Unsupported,
+            ErrorReason = "too-large",
+            GeneratorVersion = ThumbnailGenerator.Version,
+        });
+    }
+    try { await db.SaveChangesAsync(cancellationToken); }
+    catch (DbUpdateException ex) when (IsThumbnailUniqueViolation(ex)) { db.ChangeTracker.Clear(); }
+    metrics.IncrementThumbnailSkipped("too-large");
+    return;
+}
+```
+
+Rejected BEFORE any blob read. One row per variant (consumer's normal per-variant idempotency loop).
+
+### Pixel-area cap — in `MagickNetImageThumbnailer` (STRG-336)
+
+Already specified in STRG-336 — the `MagickImageInfo` probe runs on the first 64 KiB. On exceeded:
+
+```csharp
+return new ThumbnailGenerationOutcome.ResourceLimitExceeded(
+    $"pixel-cap ({pixelArea} > {options.Value.MaxPixelArea})");
+```
+
+The consumer maps this to `Status = Unsupported, ErrorReason = "pixel-cap"` + `metrics.IncrementThumbnailSkipped("pixel-cap")`.
+
+### Timeout — `CancellationTokenSource` in `MagickNetImageThumbnailer`
+
+```csharp
+using var timeoutCts = new CancellationTokenSource(
+    TimeSpan.FromSeconds(options.Value.GenerationTimeoutSeconds));
+using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+// Pass `linked.Token` to all I/O and to Task.Run(...) wrapping Magick.NET calls.
+
+catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+{
+    return new ThumbnailGenerationOutcome.TimedOut(
+        TimeSpan.FromSeconds(options.Value.GenerationTimeoutSeconds));
+}
+```
+
+Distinguishes timeout (`timeoutCts.IsCancellationRequested`) from caller cancellation (`cancellationToken.IsCancellationRequested`) — a caller-cancelled call should NOT be treated as a timeout (the message just goes back to the queue for retry).
+
+The consumer maps `TimedOut` to `Status = Failed, ErrorReason = "timeout"` + `metrics.IncrementThumbnailGenerated(format, variant, "timed-out")`.
+
+### What is NOT in v1
+
+- **In-process memory hard-cap.** Magick.NET does not expose a per-image memory budget API that we trust. The pixel-cap is the proxy. Process-isolation (STRG-344) is the proper fix.
+- **Per-tenant rate limiting.** Existing rate limiting (STRG-082) covers HTTP; consumer-side rate limiting is not in scope. If thumbnail generation becomes a noisy-neighbor issue, MassTransit's `concurrentMessageLimit` is the lever.
+- **Decode-time pixel cap from the decoder library.** Magick.NET has `ResourceLimits.Memory`, `ResourceLimits.Width`, `ResourceLimits.Height` — these are global (process-wide). Setting them at startup IS reasonable as belt-and-braces; document as a follow-up if not done in this PR.
+
+## Acceptance Criteria
+
+- [ ] Source-size check happens BEFORE any `IStorageProvider.ReadAsync` call for the source.
+- [ ] Pixel-cap check uses `MagickImageInfo` header probe, NOT a full decode.
+- [ ] Timeout uses `CancellationTokenSource` linked with the consumer CT.
+- [ ] Timeout distinguishes from caller cancellation (test coverage).
+- [ ] Each safeguard maps to a specific `ThumbnailEntry.Status` + `ErrorReason` + metric reason.
+- [ ] Defaults are: `256 MiB` / `100 MP` / `30 s`.
+
+## Test Cases
+
+- **TC-001**: Upload a 300 MiB file with default config → 3 `Unsupported{too-large}` rows; no source read; `strg_thumbnails_skipped_total{reason=too-large}` += 1.
+- **TC-002**: Upload a 100 MP PNG bomb → `Unsupported{pixel-cap}` rows; source body NOT decoded (verified by checking `MagickImage.TotalPixels` was never queried — or by timing: the test should complete in milliseconds, not seconds).
+- **TC-003**: A test generator that sleeps 60 s with default 30 s timeout → `Failed{timeout}` row; `strg_thumbnails_generated_total{status=timed-out}` += 1.
+- **TC-004**: Caller cancels mid-generation (e.g., consumer shutdown) → consumer treats it as a retryable abort, NOT as `Failed{timeout}`. Row stays `Pending` (or absent if no row was inserted yet); message goes back to the queue.
+- **TC-005**: `MaxSourceSizeBytes` config override = 1 KiB → tiny image upload still gets `too-large` (validates the gate, not just the default).
+
+## Implementation Tasks
+
+- [ ] Source-size gate in `ThumbnailGenerationConsumer.ProcessAsync`.
+- [ ] Pixel-cap probe in `MagickNetImageThumbnailer.GenerateAsync` (already in STRG-336 spec; verify present).
+- [ ] Timeout via linked CTS in `MagickNetImageThumbnailer.GenerateAsync` (already in STRG-336 spec; verify present).
+- [ ] Tests under `tests/Strg.Integration.Tests/Thumbnails/SafeguardsTests.cs` covering all five test cases.
+
+## Security Review Checklist
+
+- [ ] Pixel-cap is enforced BEFORE full decode — bomb-resistant.
+- [ ] Source-size cap is enforced BEFORE any blob I/O — minimizes attack surface.
+- [ ] Timeout cannot be set to 0 by config (validator rejects, STRG-334).
+- [ ] No way to bypass any of the three caps via a hand-crafted event payload (event has no fields that override config).
+- [ ] Caller-cancellation vs timeout is distinguished — a misclassification could cause infinite retries on legitimate cancellations.
+
+## Code Review Checklist
+
+- [ ] `using` for both `CancellationTokenSource` (timeout + linked).
+- [ ] Linked CTS uses `CreateLinkedTokenSource(consumerCt, timeoutCt.Token)`.
+- [ ] No `Task.Wait`, no `.Result` — all async.
+- [ ] Pixel-cap arithmetic uses `long` to avoid `int` overflow on 100 MP+.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Tests pass.
+- [ ] Manual smoke: configure `Thumbnails:MaxSourceSizeBytes = 1024`, upload a 2 KiB image, observe `Unsupported{too-large}` row.

--- a/docs/issues/strg/STRG-339-rest-endpoint.md
+++ b/docs/issues/strg/STRG-339-rest-endpoint.md
@@ -1,0 +1,198 @@
+---
+id: STRG-339
+title: REST GET /files/{fileId}/thumbnail with ETag/304/202-pending
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, rest-api, caching]
+depends_on: [STRG-329, STRG-331]
+blocks: [STRG-340, STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-339: REST GET /files/{fileId}/thumbnail with ETag/304/202-pending
+
+## Summary
+
+Streaming REST endpoint that serves a thumbnail blob for a given `(fileId, variant)`. Honours `If-None-Match` for 304 responses, returns `202 Accepted` while generation is still pending, and applies the project's standard auth policy (same read-permission gate as the file download endpoint).
+
+## Background / Context
+
+Thumbnails are content-addressed — same `FileVersion.ContentHash` always produces the same WebP. This is a natural fit for a strong ETag and `Cache-Control: immutable`. Browsers will cache aggressively, which is critical for grid-view performance (otherwise every gallery scroll triggers N HTTP fetches for the same WebP).
+
+`202 Accepted` exists because thumbnails are async (D1) — the file may have just been uploaded and the consumer hasn't finished yet. Returning `404` would be misleading; `202` with `Retry-After` tells the client "come back in 5 s".
+
+## Technical Specification
+
+### Endpoint — `src/Strg.Api/Endpoints/ThumbnailEndpoints.cs`
+
+```csharp
+public static class ThumbnailEndpoints
+{
+    public static IEndpointRouteBuilder MapThumbnailEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/files/{fileId:guid}/thumbnail", GetThumbnailAsync)
+           .RequireAuthorization()
+           .WithName("GetFileThumbnail")
+           .WithTags("Thumbnails");
+
+        return app;
+    }
+
+    private static async Task<IResult> GetThumbnailAsync(
+        Guid fileId,
+        [FromQuery] string variant,
+        ClaimsPrincipal user,
+        IThumbnailRepository thumbnails,
+        StrgDbContext db,
+        IStorageProvider storageProvider,
+        IFileAuthorizationService auth,                // existing service from STRG-037 download
+        HttpContext http,
+        CancellationToken cancellationToken)
+    {
+        if (!ThumbnailVariants.All.Contains(variant))
+        {
+            return Results.BadRequest(new { error = "unknown-variant", variant });
+        }
+
+        var fileVersion = await db.FileVersions
+            .AsNoTracking()
+            .Where(v => v.FileId == fileId)
+            .OrderByDescending(v => v.CreatedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+        if (fileVersion is null) { return Results.NotFound(); }
+
+        // Auth — same policy as the download endpoint.
+        if (!await auth.CanReadAsync(user, fileId, cancellationToken))
+        {
+            return Results.Forbid();
+        }
+
+        var entry = await thumbnails.GetAsync(fileVersion.Id, variant, "webp", cancellationToken);
+        if (entry is null)
+        {
+            // Generation not yet started — 202 with Retry-After.
+            http.Response.Headers["Retry-After"] = "5";
+            return Results.StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        return entry.Status switch
+        {
+            ThumbnailStatus.Pending =>
+                AcceptedWithRetryAfter(http),
+            ThumbnailStatus.Unsupported or ThumbnailStatus.Failed =>
+                Results.NotFound(),
+            ThumbnailStatus.Ready =>
+                await StreamAsync(entry, fileVersion, storageProvider, http, cancellationToken),
+            _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+        };
+    }
+}
+```
+
+### `StreamAsync` — ETag, 304, streaming response
+
+```csharp
+private static async Task<IResult> StreamAsync(
+    ThumbnailEntry entry, FileVersion fileVersion,
+    IStorageProvider storageProvider, HttpContext http,
+    CancellationToken cancellationToken)
+{
+    var etag = $"\"{fileVersion.ContentHash}-{entry.Variant}-{entry.Format}\"";
+
+    // Strong ETag, content-addressed — If-None-Match is exact match.
+    if (http.Request.Headers.IfNoneMatch.Contains(etag))
+    {
+        return Results.StatusCode(StatusCodes.Status304NotModified);
+    }
+
+    var path = StoragePath.Parse(entry.StorageKey);
+    var stream = await storageProvider.ReadAsync(path.Value, 0, cancellationToken);
+    var contentType = entry.Format == "jpeg"
+        ? MediaTypeNames.Image.Jpeg
+        : "image/webp";    // not yet in MediaTypeNames as of net10
+
+    http.Response.Headers[HeaderNames.ETag] = etag;
+    http.Response.Headers[HeaderNames.CacheControl] = "private, max-age=31536000, immutable";
+    http.Response.Headers["X-Content-Type-Options"] = "nosniff";
+
+    return Results.File(stream, contentType: contentType, enableRangeProcessing: false);
+}
+```
+
+### Status code matrix
+
+| Condition | Status | Headers |
+|---|---|---|
+| `variant` not in whitelist | 400 | `{"error":"unknown-variant"}` |
+| File missing | 404 | — |
+| User lacks read permission | 403 | — |
+| Row absent (consumer not yet hit) | 202 | `Retry-After: 5` |
+| Row `Pending` | 202 | `Retry-After: 5` |
+| Row `Failed` or `Unsupported` | 404 | — (do NOT leak the reason — the file exists, just no thumbnail) |
+| Row `Ready` + `If-None-Match` match | 304 | `ETag` echoed |
+| Row `Ready` + new request | 200 | `Content-Type`, `ETag`, `Cache-Control: immutable`, `X-Content-Type-Options: nosniff` |
+
+### Why no Range processing
+
+WebPs at our variant sizes are tiny (typically <500 KiB). Range support adds 304/206 complexity without benefit. Set `enableRangeProcessing: false`.
+
+### Why `private` not `public` cache
+
+Thumbnails are tenant-scoped — public CDN caching would leak cross-tenant if the same `fileId` GUID happened across tenants (it shouldn't, but defense in depth). `private` says "browser cache OK, shared cache NO".
+
+## Acceptance Criteria
+
+- [ ] `GET /files/{fileId}/thumbnail?variant=...` is mapped and requires auth.
+- [ ] Variant whitelist enforced (400 on unknown).
+- [ ] Auth via `IFileAuthorizationService.CanReadAsync` (same policy as download — STRG-037).
+- [ ] Status codes: 200/202/304/400/403/404 per matrix.
+- [ ] ETag is strong, composite of `ContentHash + Variant + Format`.
+- [ ] `Cache-Control: private, max-age=31536000, immutable`.
+- [ ] `X-Content-Type-Options: nosniff` set on 200 responses.
+- [ ] Streaming via `IStorageProvider.ReadAsync` — no `byte[]` buffer.
+- [ ] All thumbnail keys flow through `StoragePath.Parse()` before storage I/O.
+
+## Test Cases
+
+- **TC-001**: GET ready thumbnail → 200, `Content-Type: image/webp`, `ETag` present, `Cache-Control: immutable`, body is a valid WebP.
+- **TC-002**: GET with matching `If-None-Match` → 304, no body, `ETag` echoed.
+- **TC-003**: GET while row is `Pending` → 202, `Retry-After: 5`.
+- **TC-004**: GET when row absent (consumer hasn't fired yet) → 202, `Retry-After: 5`.
+- **TC-005**: GET when row is `Unsupported` (encrypted-drive carve-out) → 404.
+- **TC-006**: GET with `variant=enormous` → 400 with `{"error":"unknown-variant"}`.
+- **TC-007**: GET as user without read permission → 403.
+- **TC-008**: Manual `curl -I` shows `Cache-Control: private, max-age=31536000, immutable` and `ETag`.
+
+## Implementation Tasks
+
+- [ ] Add `ThumbnailEndpoints` and call `app.MapThumbnailEndpoints()` in `Program.cs`.
+- [ ] Reuse the existing `IFileAuthorizationService` from STRG-037 — do NOT duplicate auth logic.
+- [ ] Set the cache headers via `HeaderNames.*` constants (no magic strings).
+- [ ] Tests under `tests/Strg.Integration.Tests/Thumbnails/ThumbnailEndpointTests.cs`.
+
+## Security Review Checklist
+
+- [ ] Auth check happens BEFORE any blob I/O — no info leak about file existence to unauthorized callers (404 on auth fail vs 403 — chose 403 because the user MIGHT see the file in a listing they have list-permission on; aligns with download endpoint).
+- [ ] `If-None-Match` is exact-match (strong ETag), not weak/W/ comparison.
+- [ ] `Cache-Control: private` (not `public`) — no shared-cache cross-tenant leak.
+- [ ] `X-Content-Type-Options: nosniff` blocks browser MIME-sniffing on the WebP.
+- [ ] No `entry.ErrorReason` leaked in 404 response (the API does not reveal generation failure modes to unauthenticated query patterns).
+- [ ] All paths through `StoragePath.Parse()`.
+- [ ] No `entry.StorageKey` reflected back in any response header or body.
+
+## Code Review Checklist
+
+- [ ] `MediaTypeNames.Image.Jpeg` constant for JPEG; `"image/webp"` literal acceptable (not yet in BCL constants).
+- [ ] `HeaderNames.ETag`, `HeaderNames.CacheControl` from `Microsoft.Net.Http.Headers` (no magic strings).
+- [ ] `Results.File` with `enableRangeProcessing: false`.
+- [ ] No ContextAccessor abuse — `HttpContext` is a method parameter.
+- [ ] CancellationToken parameter named `cancellationToken`.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Integration tests TC-001…TC-007 named and passing.
+- [ ] Manual `curl -I` smoke captured in the PR description.

--- a/docs/issues/strg/STRG-340-graphql-field.md
+++ b/docs/issues/strg/STRG-340-graphql-field.md
@@ -1,0 +1,249 @@
+---
+id: STRG-340
+title: GraphQL FileItem.thumbnail field + Thumbnail type + DataLoader + thumbnailReady subscription
+milestone: v0.2
+priority: high
+status: open
+type: feature
+labels: [thumbnails, phase-15, graphql, dataloader, subscriptions]
+depends_on: [STRG-339, STRG-341]
+blocks: [STRG-342, STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-340: GraphQL FileItem.thumbnail field + Thumbnail type + DataLoader + thumbnailReady subscription
+
+## Summary
+
+Expose thumbnails through Hot Chocolate GraphQL: a `Thumbnail` object type, a `thumbnail(variant: ThumbnailVariant!)` field on `FileItem` (DataLoader-batched), and a live `thumbnailReady(fileId: ID!)` subscription bridged from `ThumbnailReadyEvent` (STRG-341).
+
+## Background / Context
+
+Grid-view UIs query many `FileItem.thumbnail` fields in a single GraphQL request — DataLoader batching is non-negotiable to avoid N+1 reads against `ThumbnailEntries`. The `url` field returns the REST endpoint (STRG-339) so we have a single source of truth for serving bytes; GraphQL is pure metadata.
+
+The subscription lets a single-page app refresh thumbnails as they finish generating without polling.
+
+## Technical Specification
+
+### `Thumbnail` type — `src/Strg.GraphQl/Types/ThumbnailType.cs`
+
+```csharp
+public sealed record Thumbnail(
+    string Url,
+    int? Width,
+    int? Height,
+    long? SizeBytes,
+    ThumbnailStatusGraphQl Status,
+    string? Format,
+    string? ErrorReason);
+
+public sealed class ThumbnailType : ObjectType<Thumbnail>
+{
+    protected override void Configure(IObjectTypeDescriptor<Thumbnail> descriptor)
+    {
+        descriptor.Field(t => t.Url).Type<NonNullType<StringType>>();
+        descriptor.Field(t => t.Status).Type<NonNullType<EnumType<ThumbnailStatusGraphQl>>>();
+        descriptor.Field(t => t.ErrorReason)
+                  .Description("Human-readable reason when status is FAILED or UNSUPPORTED. Null otherwise.");
+    }
+}
+
+public enum ThumbnailStatusGraphQl { Pending, Ready, Failed, Unsupported }
+
+// Maps domain → GraphQL enum (the names happen to match; explicit conversion centralizes future drift).
+public static class ThumbnailStatusMap
+{
+    public static ThumbnailStatusGraphQl FromDomain(ThumbnailStatus s) => (ThumbnailStatusGraphQl)s;
+}
+```
+
+`Url` is always populated — points to the REST endpoint. The client follows it; GraphQL doesn't stream bytes.
+
+### `ThumbnailVariant` enum — `src/Strg.GraphQl/Types/ThumbnailVariantType.cs`
+
+```csharp
+public enum ThumbnailVariantGraphQl { Thumb, Small, Medium }
+```
+
+(Mirrors `ThumbnailVariants` strings; Hot Chocolate auto-derives the enum schema.)
+
+### `FileItem.thumbnail` field — `src/Strg.GraphQl/Types/FileItemType.cs`
+
+Add to the existing `FileItemType` configuration:
+
+```csharp
+descriptor
+    .Field("thumbnail")
+    .Argument("variant", a => a.Type<NonNullType<EnumType<ThumbnailVariantGraphQl>>>())
+    .Type<ThumbnailType>()
+    .Resolve(async ctx =>
+    {
+        var fileItem = ctx.Parent<FileItem>();
+        var variant = ctx.ArgumentValue<ThumbnailVariantGraphQl>("variant");
+        var loader = ctx.DataLoader<ThumbnailDataLoader>();
+        return await loader.LoadAsync(
+            new ThumbnailKey(fileItem.Id, variant.ToVariantString()),
+            ctx.RequestAborted);
+    });
+```
+
+### `ThumbnailDataLoader` — `src/Strg.GraphQl/DataLoaders/ThumbnailDataLoader.cs`
+
+```csharp
+public sealed record ThumbnailKey(Guid FileId, string Variant);
+
+public sealed class ThumbnailDataLoader(
+    IBatchScheduler scheduler,
+    IDbContextFactory<StrgDbContext> dbFactory,
+    DataLoaderOptions options,
+    LinkGenerator linkGenerator)
+    : BatchDataLoader<ThumbnailKey, Thumbnail>(scheduler, options)
+{
+    protected override async Task<IReadOnlyDictionary<ThumbnailKey, Thumbnail>> LoadBatchAsync(
+        IReadOnlyList<ThumbnailKey> keys, CancellationToken cancellationToken)
+    {
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Group by variant for predicate efficiency, then collect.
+        var fileIds = keys.Select(k => k.FileId).Distinct().ToList();
+        var variants = keys.Select(k => k.Variant).Distinct().ToList();
+
+        // Latest version per file → corresponding ThumbnailEntry per (variant, format=webp).
+        var rows = await (from t in db.ThumbnailEntries
+                          join v in db.FileVersions on t.FileVersionId equals v.Id
+                          where fileIds.Contains(v.FileId)
+                                && variants.Contains(t.Variant)
+                                && t.Format == "webp"
+                          select new { v.FileId, t })
+                         .ToListAsync(cancellationToken);
+
+        // For each (FileId, Variant), pick the row tied to the LATEST version.
+        // (Cleanup ensures stale-version rows are gone, but defence in depth.)
+        return rows
+            .GroupBy(r => new ThumbnailKey(r.FileId, r.t.Variant))
+            .ToDictionary(
+                g => g.Key,
+                g => MapToGraphQl(g.OrderByDescending(r => r.t.GeneratedAt ?? DateTimeOffset.MinValue).First().t));
+    }
+
+    private Thumbnail MapToGraphQl(ThumbnailEntry t) => new(
+        Url: BuildRestUrl(t.FileVersionId, t.Variant),
+        Width: t.Status == ThumbnailStatus.Ready ? t.Width : null,
+        Height: t.Status == ThumbnailStatus.Ready ? t.Height : null,
+        SizeBytes: t.Status == ThumbnailStatus.Ready ? t.SizeBytes : null,
+        Status: (ThumbnailStatusGraphQl)t.Status,
+        Format: t.Status == ThumbnailStatus.Ready ? t.Format : null,
+        ErrorReason: t.ErrorReason);
+}
+```
+
+The `BuildRestUrl` helper uses `LinkGenerator.GetPathByName("GetFileThumbnail", new { fileId = ..., variant = ... })` to avoid hard-coding paths.
+
+### Subscription — `src/Strg.GraphQl/Subscriptions/ThumbnailSubscriptions.cs`
+
+```csharp
+[ExtendObjectType("Subscription")]
+public sealed class ThumbnailSubscriptions
+{
+    [Subscribe(With = nameof(SubscribeToThumbnailReady))]
+    public Thumbnail ThumbnailReady(
+        Guid fileId,
+        [EventMessage] ThumbnailReadyEvent evt,
+        [Service] LinkGenerator linkGenerator) =>
+        new Thumbnail(
+            Url: BuildRestUrl(linkGenerator, evt.FileId, evt.Variant),
+            Width: evt.Width, Height: evt.Height,
+            SizeBytes: null,                        // not in event; client can re-fetch via DataLoader
+            Status: ThumbnailStatusGraphQl.Ready,
+            Format: evt.Format,
+            ErrorReason: null);
+
+    public ValueTask<ISourceStream<ThumbnailReadyEvent>> SubscribeToThumbnailReady(
+        Guid fileId,
+        [Service] ITopicEventReceiver receiver,
+        CancellationToken cancellationToken) =>
+        receiver.SubscribeAsync<ThumbnailReadyEvent>(
+            $"thumbnail-ready:{fileId}", cancellationToken);
+}
+```
+
+The publisher (`GraphQlSubscriptionPublisher`, STRG-341) sends to topic `thumbnail-ready:{fileId}` so the subscription scopes per-file.
+
+### Schema example
+
+```graphql
+type FileItem {
+  id: ID!
+  name: String!
+  thumbnail(variant: ThumbnailVariantGraphQl!): Thumbnail
+  # ... other fields
+}
+
+type Thumbnail {
+  url: String!
+  width: Int
+  height: Int
+  sizeBytes: BigInt
+  status: ThumbnailStatusGraphQl!
+  format: String
+  errorReason: String
+}
+
+enum ThumbnailStatusGraphQl { PENDING, READY, FAILED, UNSUPPORTED }
+enum ThumbnailVariantGraphQl { THUMB, SMALL, MEDIUM }
+
+type Subscription {
+  thumbnailReady(fileId: ID!): Thumbnail!
+}
+```
+
+## Acceptance Criteria
+
+- [ ] `Thumbnail` GraphQL type exposes `url`, `width`, `height`, `sizeBytes`, `status`, `format`, `errorReason`.
+- [ ] `FileItem.thumbnail(variant: ThumbnailVariantGraphQl!)` field is registered.
+- [ ] `ThumbnailDataLoader` batches lookups within a single GraphQL request (no N+1 SQL on the thumbnails table).
+- [ ] `url` is built via `LinkGenerator.GetPathByName("GetFileThumbnail", ...)` — no hard-coded path.
+- [ ] `thumbnailReady(fileId: ID!)` subscription is registered and fires on `ThumbnailReadyEvent` (STRG-341 wires the publisher).
+- [ ] Status enum maps the four domain states.
+- [ ] `errorReason` is null for `Ready`; populated for `Failed` and `Unsupported`.
+
+## Test Cases
+
+- **TC-001**: GraphQL query `{ files { id thumbnail(variant: SMALL) { url status width height } } }` for 50 files runs ONE batched SQL query against `ThumbnailEntries` (verified via EF logging or test diagnostics).
+- **TC-002**: Field returns `status: PENDING` immediately after upload, `status: READY` after the consumer fires.
+- **TC-003**: Subscription `subscription { thumbnailReady(fileId: $id) { url status } }` receives a payload after `ThumbnailReadyEvent` fires.
+- **TC-004**: `thumbnail(variant: MEDIUM)` for an encrypted-drive file returns `status: UNSUPPORTED, errorReason: "encrypted-drive-not-yet-supported"`.
+- **TC-005**: `url` is the REST endpoint path including the correct variant query.
+
+## Implementation Tasks
+
+- [ ] Add `Thumbnail`, `ThumbnailType`, `ThumbnailStatusGraphQl`, `ThumbnailVariantGraphQl`.
+- [ ] Add `ThumbnailDataLoader` (batch).
+- [ ] Extend `FileItemType` with the `thumbnail` field.
+- [ ] Add `ThumbnailSubscriptions` extending `Subscription` type.
+- [ ] Register all in the existing GraphQL configuration.
+- [ ] Tests under `tests/Strg.GraphQl.Tests/Thumbnails/` (DataLoader test) + `tests/Strg.Integration.Tests/Thumbnails/ThumbnailGraphQlTests.cs` (end-to-end + subscription).
+
+## Security Review Checklist
+
+- [ ] DataLoader respects tenant filter (inherits from `StrgDbContext` which has the global filter).
+- [ ] `url` is server-built — never reflected from user input. Variant comes from the GraphQL enum (already validated).
+- [ ] `errorReason` exposed in GraphQL is bounded (max 256 chars per the entity column).
+- [ ] Subscription topic is per-file — subscribing to `fileId=X` only delivers events for that file.
+- [ ] Subscription does NOT bypass auth — `RequireAuthorization` on the subscription endpoint.
+- [ ] No `entry.StorageKey` is exposed in any GraphQL payload.
+
+## Code Review Checklist
+
+- [ ] DataLoader extends `BatchDataLoader<,>` (Hot Chocolate v15+).
+- [ ] DataLoader uses `IDbContextFactory<>` (DataLoaders may outlive a request scope).
+- [ ] No `Task.Wait`, no `.Result`.
+- [ ] `ITopicEventReceiver` from `HotChocolate.Subscriptions` (matches existing pattern in `GraphQlSubscriptionPublisher`).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Tests pass.
+- [ ] Banana Cake Pop / Nitro can introspect the new schema.
+- [ ] DataLoader batching verified by EF Core query logging in TC-001.

--- a/docs/issues/strg/STRG-341-ready-event.md
+++ b/docs/issues/strg/STRG-341-ready-event.md
@@ -1,0 +1,131 @@
+---
+id: STRG-341
+title: ThumbnailReadyEvent + GraphQlSubscriptionPublisher wiring
+milestone: v0.2
+priority: medium
+status: open
+type: feature
+labels: [thumbnails, phase-15, events, subscriptions, graphql]
+depends_on: [STRG-331]
+blocks: [STRG-340]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: small
+---
+
+# STRG-341: ThumbnailReadyEvent + GraphQlSubscriptionPublisher wiring
+
+## Summary
+
+Add `ThumbnailReadyEvent` (already declared as part of STRG-330 deliverables) to the publish path of `ThumbnailGenerationConsumer` (STRG-331) and extend `GraphQlSubscriptionPublisher` (`src/Strg.GraphQl/Consumers/GraphQlSubscriptionPublisher.cs:10-64`) with a new `IConsumer<ThumbnailReadyEvent>` so subscribers of `thumbnailReady(fileId)` see the payload.
+
+## Background / Context
+
+The publisher already follows the multi-`IConsumer<T>` pattern — see the existing class which implements `IConsumer<FileUploadedEvent>`, `IConsumer<FileDeletedEvent>`, `IConsumer<FileMovedEvent>`, etc. We add one more interface implementation. No new class.
+
+The publish-from-consumer happens BEFORE `SaveChangesAsync` so the outbox transaction stages the event atomically with the row update. This is the pattern documented in `04-event-system.md:90-108` and used everywhere in the codebase.
+
+The subscription is **live-only** — no durable history, no replay. If the client disconnects before the event arrives, they re-fetch via the DataLoader (STRG-340) which gives them the current state.
+
+## Technical Specification
+
+### Event (already in STRG-330's scope) — `src/Strg.Core/Events/ThumbnailReadyEvent.cs`
+
+```csharp
+public sealed record ThumbnailReadyEvent(
+    Guid TenantId, Guid FileId, Guid FileVersionId,
+    string Variant, string Format, int Width, int Height) : IDomainEvent;
+```
+
+### Publisher extension — `src/Strg.GraphQl/Consumers/GraphQlSubscriptionPublisher.cs`
+
+Existing class signature:
+
+```csharp
+public sealed class GraphQlSubscriptionPublisher(ITopicEventSender sender, ILogger<GraphQlSubscriptionPublisher> logger)
+    : IConsumer<FileUploadedEvent>,
+      IConsumer<FileDeletedEvent>,
+      IConsumer<FileMovedEvent>,
+      IConsumer<FileCopiedEvent>,
+      IConsumer<FileRenamedEvent>,
+      IConsumer<QuotaWarningEvent>
+```
+
+Add:
+
+```csharp
+      IConsumer<ThumbnailReadyEvent>
+```
+
+```csharp
+public Task Consume(ConsumeContext<ThumbnailReadyEvent> ctx) =>
+    sender.SendAsync(
+        $"thumbnail-ready:{ctx.Message.FileId}",
+        ctx.Message,
+        ctx.CancellationToken).AsTask();
+```
+
+The topic key matches the subscriber side from STRG-340.
+
+### Generation consumer publish — STRG-331 update
+
+Inside `ThumbnailGenerationConsumer.ProcessAsync`, after a successful per-variant write but BEFORE the per-variant `SaveChangesAsync`:
+
+```csharp
+// Variant succeeded → row at Ready, blob written. Stage subscription event.
+await bus.Publish(
+    new ThumbnailReadyEvent(
+        tenantId, fileId, version.Id,
+        variant, "webp", result.Width, result.Height),
+    cancellationToken);
+
+await db.SaveChangesAsync(cancellationToken);   // commits row + outbox event atomically
+```
+
+Outbox semantics: the `IPublishEndpoint.Publish` call writes to the outbox table inside the same DbContext; `SaveChangesAsync` commits both. The poller dispatches the event, which the publisher then forwards to subscribers.
+
+### Why a dedicated subscription event (not republish via direct ITopicEventSender)
+
+The consumer cannot call `ITopicEventSender.SendAsync` directly because it's outside the GraphQL request pipeline and the topic-event abstraction is tied to the GraphQL host. Using a domain event lets MassTransit handle the cross-pipeline hop and gives us the same outbox guarantees as `FileUploadedEvent`. Idempotency: re-delivery of `ThumbnailReadyEvent` re-publishes to the topic, which subscribers handle as a no-op (same payload).
+
+## Acceptance Criteria
+
+- [ ] `ThumbnailReadyEvent` published to outbox before `SaveChangesAsync` for every successful variant generation.
+- [ ] `GraphQlSubscriptionPublisher` consumes `ThumbnailReadyEvent` and forwards to topic `thumbnail-ready:{fileId}`.
+- [ ] Topic key matches the subscriber side (STRG-340).
+- [ ] Re-delivery of the event causes a duplicate topic send (acceptable — subscribers tolerate it; client-side dedup if needed).
+- [ ] No new class created — the existing publisher gets one more `IConsumer<>` interface.
+- [ ] Event registration in `Program.cs` MassTransit config: `busCfg.AddConsumer<GraphQlSubscriptionPublisher>()` already exists; just verify no extra registration needed.
+
+## Test Cases
+
+- **TC-001**: Generate a thumbnail → outbox row for `ThumbnailReadyEvent` exists in `outbox_messages` (or equivalent MassTransit table).
+- **TC-002**: Subscribe to `thumbnailReady(fileId: X)`, generate a thumbnail for X → subscriber receives one payload with `status: READY` and matching `variant` / `format` / `width` / `height`.
+- **TC-003**: Subscribe to `thumbnailReady(fileId: X)`, generate a thumbnail for Y → subscriber receives nothing (topic isolation per fileId).
+- **TC-004**: Re-deliver the event → subscriber receives two payloads (acceptable; subscribers MUST be idempotent or tolerate dupes).
+
+## Implementation Tasks
+
+- [ ] Add `IConsumer<ThumbnailReadyEvent>` to `GraphQlSubscriptionPublisher` class declaration.
+- [ ] Implement the `Consume(ConsumeContext<ThumbnailReadyEvent>)` method.
+- [ ] Add the `await bus.Publish(new ThumbnailReadyEvent(...), ct)` call at the appropriate point in `ThumbnailGenerationConsumer.ProcessAsync` (STRG-331).
+- [ ] Tests under `tests/Strg.GraphQl.Tests/Subscriptions/ThumbnailSubscriptionTests.cs` (publisher unit) + the integration test in STRG-340 (end-to-end subscription).
+
+## Security Review Checklist
+
+- [ ] Topic key uses `fileId` only — no `tenantId` in the topic name (the GraphQL subscription endpoint already authorizes the subscriber against the file).
+- [ ] Subscription endpoint requires auth (covered by the existing GraphQL auth pipeline; verify subscription operations are NOT bypassed).
+- [ ] Event payload carries `TenantId` for any future cross-pipeline routing — but the topic-publish path doesn't use it (auth happened upstream).
+- [ ] No PII in the event (`Variant`, `Format`, `Width`, `Height` are all bounded server-side values).
+
+## Code Review Checklist
+
+- [ ] No new class — just an interface addition and a `Consume` method on the existing publisher.
+- [ ] Topic-key string follows the same `{type}-{id}` convention as the existing publisher (e.g., `drive-events:{driveId}`).
+- [ ] `await bus.Publish` happens BEFORE `SaveChangesAsync` (outbox).
+- [ ] No magic-string topic format — extract a small helper if the publisher already has one (`Topics.FileEvents(...)` exists in the existing class).
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Tests pass.
+- [ ] End-to-end smoke (with STRG-340): upload → subscribe → see payload arrive.

--- a/docs/issues/strg/STRG-342-backfill.md
+++ b/docs/issues/strg/STRG-342-backfill.md
@@ -1,0 +1,152 @@
+---
+id: STRG-342
+title: Admin-triggered backfill + ThumbnailGenerationRequestedEvent
+milestone: v0.2
+priority: medium
+status: open
+type: feature
+labels: [thumbnails, phase-15, admin, backfill, graphql]
+depends_on: [STRG-331, STRG-340]
+blocks: [STRG-343]
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: medium
+---
+
+# STRG-342: Admin-triggered backfill + ThumbnailGenerationRequestedEvent
+
+## Summary
+
+Admin-only GraphQL mutation `regenerateThumbnails(driveId: ID, olderThan: DateTime)` that enumerates `FileVersion` rows lacking a `Ready` or `Unsupported` thumbnail entry and publishes a dedicated `ThumbnailGenerationRequestedEvent` per file to the outbox. The generation consumer (STRG-331) already handles both `FileUploadedEvent` AND `ThumbnailGenerationRequestedEvent` via a shared private method.
+
+## Background / Context
+
+Two scenarios drive this feature:
+
+1. **Phase 16 retrofit** — when STRG-345 (PDF) ships, every existing PDF in storage needs thumbnails. Backfill must work for new MIME types without re-deploying the consumer.
+2. **Algorithm bumps** — `ThumbnailEntry.GeneratorVersion` (STRG-329) tracks which generator produced a row. A future generator-version bump (e.g., new EXIF strip rules) requires a forced re-gen.
+
+Issue #52 explicitly chose **dedicated event** over **republished `FileUploadedEvent`**: republishing would double-write `AuditEntry` rows via `AuditLogConsumer`. The dedicated event is consumed by `ThumbnailGenerationConsumer` only.
+
+## Technical Specification
+
+### Mutation — `src/Strg.GraphQl/Mutations/RegenerateThumbnailsMutation.cs`
+
+```csharp
+[ExtendObjectType("Mutation")]
+public sealed class RegenerateThumbnailsMutation
+{
+    [Authorize(Roles = new[] { "admin" })]
+    public async Task<RegenerateThumbnailsPayload> RegenerateThumbnails(
+        Guid? driveId,
+        DateTime? olderThan,
+        [Service] StrgDbContext db,
+        [Service] IPublishEndpoint bus,
+        [Service] ITenantContext tenant,
+        CancellationToken cancellationToken)
+    {
+        var query = db.FileVersions.AsQueryable();
+
+        if (driveId is { } d)
+        {
+            query = from v in query
+                    join f in db.Files on v.FileId equals f.Id
+                    where f.DriveId == d
+                    select v;
+        }
+
+        if (olderThan is { } cutoff)
+        {
+            query = query.Where(v => v.CreatedAt < cutoff);
+        }
+
+        // Versions without ANY Ready/Unsupported row across all variants.
+        // (We don't filter per-variant — the consumer decides which variants need work.)
+        query = query.Where(v => !db.ThumbnailEntries.Any(t =>
+            t.FileVersionId == v.Id
+            && (t.Status == ThumbnailStatus.Ready || t.Status == ThumbnailStatus.Unsupported)));
+
+        var candidates = await query
+            .Select(v => new { v.FileId, v.Id, v.File.DriveId })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        foreach (var c in candidates)
+        {
+            await bus.Publish(
+                new ThumbnailGenerationRequestedEvent(
+                    tenant.TenantId, c.FileId, c.Id, c.DriveId),
+                cancellationToken);
+        }
+
+        await db.SaveChangesAsync(cancellationToken);   // commits outbox events
+
+        return new RegenerateThumbnailsPayload(candidates.Count);
+    }
+}
+
+public sealed record RegenerateThumbnailsPayload(int FilesQueued);
+```
+
+### Consumer extension — STRG-331 update
+
+`ThumbnailGenerationConsumer` already implements `IConsumer<ThumbnailGenerationRequestedEvent>` (per STRG-331's spec). The shared `ProcessAsync` method handles both event types identically. No change required here.
+
+### Why "Files queued" not "Files processed"
+
+The mutation returns immediately after staging outbox events — the actual generation is async. Returning `FilesQueued` (count) sets correct expectations. The admin UI polls with `inboxFiles` or refreshes the affected files; the GraphQL subscription `thumbnailReady` fires for each.
+
+### Pagination / batching
+
+For a large drive (10K+ files), the mutation returns a list of all candidates and stages all events in a single transaction. This is fine for v1 since the outbox dispatches lazily and the consumer's MassTransit pipeline rate-limits via `concurrentMessageLimit` (default per-process). If admins start backfilling million-file drives, follow-up work would chunk the publish into smaller transactions — flagged in STRG-344 / future issue.
+
+### Auth — admin-only
+
+`[Authorize(Roles = new[] { "admin" })]` honours the existing role policy (STRG-013 wires JWT role claims). Non-admin callers get a GraphQL error mapped from the auth pipeline.
+
+## Acceptance Criteria
+
+- [ ] Mutation `regenerateThumbnails` exists, admin-only (`[Authorize(Roles = ["admin"])]`).
+- [ ] Optional `driveId` and `olderThan` arguments filter the candidate set.
+- [ ] Candidate set is `FileVersion` rows WITHOUT a `Ready` OR `Unsupported` thumbnail entry across all variants.
+- [ ] One `ThumbnailGenerationRequestedEvent` published per candidate file.
+- [ ] Returns `RegenerateThumbnailsPayload(filesQueued: Int!)`.
+- [ ] No `AuditEntry` row produced by the backfill (the consumer is the only handler of `ThumbnailGenerationRequestedEvent`; `AuditLogConsumer` does not subscribe to it).
+- [ ] Generation consumer treats backfill events identically to `FileUploadedEvent` (same idempotency, same metrics).
+
+## Test Cases
+
+- **TC-001**: Drive with 10 files (none have thumbnails) → mutation returns `filesQueued: 10` → consumer fires for each → all 30 thumbnail rows reach `Ready` (10 files × 3 variants).
+- **TC-002**: Drive with 5 ready + 5 unsupported (encrypted-drive carve-out) + 3 missing files → mutation returns `filesQueued: 3` (skips ready and unsupported).
+- **TC-003**: `olderThan` = `1 hour ago` → only files older than 1 hour are queued.
+- **TC-004**: Non-admin caller → mutation returns auth error (no events published).
+- **TC-005**: No `AuditEntry` row appears for the queued events (verified by query against `AuditEntries` after the test) — only the consumer's own audit (if any) writes audit rows, and the consumer doesn't write audit rows for backfill.
+- **TC-006**: Re-run the mutation → already-`Ready` files are skipped → `filesQueued: 0` → no duplicate work.
+
+## Implementation Tasks
+
+- [ ] Add `RegenerateThumbnailsMutation` extending `Mutation` type.
+- [ ] Add `RegenerateThumbnailsPayload` record.
+- [ ] Verify `ThumbnailGenerationConsumer` already handles `ThumbnailGenerationRequestedEvent` (STRG-331).
+- [ ] Verify `AuditLogConsumer` does NOT subscribe to `ThumbnailGenerationRequestedEvent`.
+- [ ] Tests under `tests/Strg.Integration.Tests/Thumbnails/ThumbnailBackfillTests.cs`.
+
+## Security Review Checklist
+
+- [ ] Admin-role gate enforced (`[Authorize(Roles = ["admin"])]`).
+- [ ] Tenant scoping: candidate query inherits the tenant filter (no `IgnoreQueryFilters`).
+- [ ] `driveId` argument validated to belong to the caller's tenant (the EF tenant filter handles this; cross-tenant `driveId` produces an empty candidate set, not an error).
+- [ ] `olderThan` is bounded by the EF query — no raw SQL.
+- [ ] Backfill cannot be used to mass-trigger CPU-heavy generation as a DoS vector against the operator (it's admin-only; the only attacker who can call it is a compromised admin account, in which case other access is the bigger concern).
+
+## Code Review Checklist
+
+- [ ] `[Authorize]` attribute on the mutation method.
+- [ ] EF query is composable (`AsQueryable()`); no premature `ToList()`.
+- [ ] No `Distinct()` on a non-keyed projection — the `.Distinct()` here projects unique `(FileId, Id, DriveId)` triples which is fine.
+- [ ] No N+1 — single bulk publish loop.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Tests pass.
+- [ ] Manual smoke: as admin, run `mutation { regenerateThumbnails(driveId: $id) { filesQueued } }`, observe events fired and rows reach `Ready`.

--- a/docs/issues/strg/STRG-343-integration-tests.md
+++ b/docs/issues/strg/STRG-343-integration-tests.md
@@ -1,0 +1,202 @@
+---
+id: STRG-343
+title: Integration tests — happy path, bomb, encrypted-drive, prune, extension-point
+milestone: v0.2
+priority: high
+status: open
+type: testing
+labels: [thumbnails, phase-15, integration-tests, testcontainers]
+depends_on: [STRG-336, STRG-337, STRG-338, STRG-339, STRG-340, STRG-342]
+blocks: []
+assigned_agent_type: feature-dev:code-architect
+estimated_complexity: large
+---
+
+# STRG-343: Integration tests — happy path, bomb, encrypted-drive, prune, extension-point
+
+## Summary
+
+Comprehensive integration tests for the thumbnail subsystem. Real binary fixtures, Testcontainers (PostgreSQL + RabbitMQ + InMemoryStorageProvider), `ITestHarness` + `IOutboxFlusher` orchestration. Zero `Thread.Sleep` / `Task.Delay`. Includes the extension-point sanity test that proves Phase 16 will be additive.
+
+## Background / Context
+
+Issue #52 says: "Real files (small PNG, WebP, animated GIF, orientation-tagged JPEG, corrupt JPEG, 100 MP PNG bomb)". The test suite must cover every TC the parent issue lists. Pattern follows `tests/Strg.Integration.Tests/Messaging/AuditLogConsumerTests.cs:33-53, 410-434` exactly — same Testcontainers setup, same harness build.
+
+## Technical Specification
+
+### Test class layout
+
+| File | Coverage |
+|---|---|
+| `tests/Strg.Integration.Tests/Thumbnails/ThumbnailGenerationConsumerTests.cs` | TC-003, TC-004, TC-006, TC-012 (happy path, idempotency, encrypted-drive, timeout) |
+| `tests/Strg.Integration.Tests/Thumbnails/ThumbnailEndpointTests.cs` | TC-009 (REST ETag/304/Cache-Control) |
+| `tests/Strg.Integration.Tests/Thumbnails/ThumbnailCleanupTests.cs` | TC-007, TC-008 (file delete + version prune propagation) |
+| `tests/Strg.Integration.Tests/Thumbnails/ImageGeneratorTests.cs` | TC-005, TC-011 (pixel bomb, EXIF orientation + metadata strip) |
+| `tests/Strg.Integration.Tests/Thumbnails/ThumbnailBackfillTests.cs` | TC-006 (encrypted-drive backfill) + STRG-342 backfill cases |
+| `tests/Strg.Integration.Tests/Thumbnails/ThumbnailGraphQlTests.cs` | TC-001, TC-010 (DataLoader batching, extension-point) |
+| `tests/Strg.Integration.Tests/Thumbnails/ExtensionPointTests.cs` | TC-010 (fake `TxtThumbnailer` registers, backfill routes to it) |
+
+### Harness pattern
+
+```csharp
+public sealed class ThumbnailGenerationConsumerTests(ITestOutputHelper output) : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:17-alpine").Build();
+    private readonly RabbitMqContainer _rabbitMq = new RabbitMqBuilder("rabbitmq:3.13-management-alpine").Build();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+        await _rabbitMq.StartAsync();
+    }
+
+    private async Task<(IServiceProvider Provider, ITestHarness Harness, StrgDbContext Db, IOutboxFlusher Flusher)> BuildAsync(
+        Action<IServiceCollection>? overrides = null)
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<StrgDbContext>(o =>
+            o.UseNpgsql(_postgres.GetConnectionString()));
+
+        services.AddMassTransitTestHarness(bus =>
+        {
+            bus.AddConsumer<ThumbnailGenerationConsumer>();
+            bus.AddConsumer<ThumbnailGenerationFaultObserver>();
+            bus.AddConsumer<ThumbnailCleanupConsumer>();
+            bus.AddEntityFrameworkOutbox<StrgDbContext>(outbox =>
+            {
+                outbox.UsePostgres();
+                outbox.UseBusOutbox();
+                outbox.QueryDelay = TimeSpan.FromSeconds(1);
+            });
+            bus.UsingRabbitMq((ctx, cfg) =>
+            {
+                cfg.Host(new Uri(_rabbitMq.GetConnectionString()));
+                cfg.UseMessageRetry(r => r.Immediate(2));
+                cfg.ConfigureEndpoints(ctx);
+            });
+        });
+
+        services.AddSingleton<IThumbnailGenerator, MagickNetImageThumbnailer>();
+        services.AddSingleton<IThumbnailGeneratorRegistry, ThumbnailGeneratorRegistry>();
+        services.AddSingleton<IThumbnailRepository, ThumbnailRepository>();
+        services.AddSingleton<IStorageProvider, InMemoryStorageProvider>();
+        services.AddSingleton<StrgMetrics>();
+        services.AddSingleton(TimeProvider.System);
+        services.Configure<ThumbnailOptions>(o => { /* test defaults */ });
+
+        overrides?.Invoke(services);
+
+        var provider = services.BuildServiceProvider();
+        var harness = provider.GetRequiredService<ITestHarness>();
+        await harness.Start();
+
+        var db = provider.GetRequiredService<StrgDbContext>();
+        await db.Database.MigrateAsync();
+
+        var flusher = provider.GetRequiredService<IOutboxFlusher>();
+        return (provider, harness, db, flusher);
+    }
+}
+```
+
+### Test fixtures — `tests/Strg.Integration.Tests/Thumbnails/Fixtures/`
+
+| File | Purpose |
+|---|---|
+| `small.jpg` | Baseline JPEG (e.g., 600×400, ~50 KiB) |
+| `small.png` | Baseline PNG with transparency |
+| `small.webp` | Baseline WebP |
+| `animated.gif` | 3-frame GIF |
+| `corrupt.jpg` | Truncated JPEG (header only) |
+| `bomb.png` | 100 MP-class image header (palette PNG; the actual pixel data can be small after compression — only the header dimensions matter) |
+| `portrait-orientation.jpg` | EXIF Orientation = 6 |
+| `gps-tagged.heic` | HEIC with embedded GPS |
+| `metadata-rich.tiff` | TIFF with EXIF + IPTC + XMP |
+
+**Fixture generation note**: the `bomb.png` cannot legitimately be 100 MP of pixel data in source control (~400 MB). It can be a crafted PNG header that ADVERTISES 10000×10000 dimensions but has minimal IDAT — the `MagickImageInfo` probe reads dimensions from the header, which is what we're testing. Document this in a `Fixtures/README.md`.
+
+### Extension-point test — `ExtensionPointTests.cs`
+
+```csharp
+[Fact]
+public async Task BackfillRoutesToFakeGenerator_ProvesPhase16IsAdditive()
+{
+    // Arrange: register a fake "txt" generator
+    var (provider, harness, db, flusher) = await BuildAsync(overrides: services =>
+    {
+        services.AddSingleton<IThumbnailGenerator, FakeTxtThumbnailer>();
+    });
+
+    var version = await SeedFileVersionAsync(db, mimeType: "text/plain", contents: "hello");
+
+    // Act: publish backfill event (the same event the admin mutation would publish)
+    await harness.Bus.Publish(new ThumbnailGenerationRequestedEvent(
+        tenantId, version.FileId, version.Id, version.DriveId));
+
+    await flusher.FlushAsync();
+    await harness.WaitForConsumed<ThumbnailGenerationRequestedEvent>();
+
+    // Assert: 3 Ready rows exist (one per variant), Format = "txt-icon" (fake's output)
+    var rows = await db.ThumbnailEntries.Where(t => t.FileVersionId == version.Id).ToListAsync();
+    Assert.Equal(3, rows.Count);
+    Assert.All(rows, r => Assert.Equal(ThumbnailStatus.Ready, r.Status));
+    Assert.All(rows, r => Assert.Equal("txt-icon", r.Format));
+}
+
+private sealed class FakeTxtThumbnailer : IThumbnailGenerator
+{
+    public bool CanHandle(string mimeType, ReadOnlySpan<byte> magicBytes) =>
+        mimeType == "text/plain";
+    public Task<ThumbnailGenerationOutcome> GenerateAsync(Stream s, ThumbnailRequest r, CancellationToken ct) =>
+        Task.FromResult<ThumbnailGenerationOutcome>(
+            new ThumbnailGenerationOutcome.Success(new MemoryStream(new byte[]{1,2,3}), 1, 1, "txt-icon"));
+}
+```
+
+This proves the extension-point contract: NO consumer change, NO API change, NO DB change to support a new generator.
+
+### Zero-sleep guarantee
+
+All waits go through `IOutboxFlusher.FlushAsync()` and `harness.WaitForConsumed<T>()`. Document in test class doc-comment: "Adding `Thread.Sleep` / `Task.Delay` is a CI-flake bug; flag in review."
+
+## Acceptance Criteria
+
+- [ ] All seven test classes exist with the coverage matrix above.
+- [ ] Test fixtures committed under `Fixtures/`; fixture README documents how each was generated.
+- [ ] Zero `Thread.Sleep` / `Task.Delay` in test code (architecture test or grep enforces).
+- [ ] Testcontainers PostgreSQL + RabbitMQ; storage uses `InMemoryStorageProvider` per CLAUDE.md.
+- [ ] Extension-point test (`FakeTxtThumbnailer`) proves the Phase 16 contract.
+- [ ] Each TC-001…TC-012 from issue #52 has a named test method (mapping documented in the PR description).
+
+## Test Cases
+
+(All TC-001 through TC-012 from issue #52 are covered. See the test-class layout table above for which file each lives in.)
+
+## Implementation Tasks
+
+- [ ] Build the Testcontainers-based harness factory (one per test class, per existing pattern).
+- [ ] Add fixture binaries; document generation steps.
+- [ ] Implement all seven test classes.
+- [ ] `FakeTxtThumbnailer` for the extension-point test.
+- [ ] Verify zero-sleep via grep / architecture test.
+
+## Security Review Checklist
+
+- [ ] No credentials in test code or fixtures.
+- [ ] Fixture binaries don't contain real GPS coordinates / camera serials (synthetic test data only).
+- [ ] `bomb.png` fixture is documented as a crafted-header file — won't accidentally consume 400 MB of disk if a contributor decompresses it.
+- [ ] Tests don't write to the production-like blob path; `InMemoryStorageProvider` keeps everything in-memory.
+
+## Code Review Checklist
+
+- [ ] `IAsyncLifetime` (xunit) for container lifecycle.
+- [ ] One `PostgreSqlContainer` + one `RabbitMqContainer` per test class (existing project convention — NOT shared across classes for isolation).
+- [ ] `IOutboxFlusher.FlushAsync()` + `harness.WaitForConsumed<T>()` for sync points.
+- [ ] No `Task.Delay` anywhere.
+
+## Definition of Done
+
+- [ ] All acceptance criteria green.
+- [ ] Per CLAUDE.md S1 trigger: full integration suite handed to user (Claude does NOT auto-run).
+- [ ] Targeted run: `dotnet test tests/Strg.Integration.Tests --filter "FullyQualifiedName~Thumbnail"` passes locally.
+- [ ] PR description maps each TC to its test method.

--- a/docs/issues/strg/STRG-344-sandbox-design.md
+++ b/docs/issues/strg/STRG-344-sandbox-design.md
@@ -1,0 +1,125 @@
+---
+id: STRG-344
+title: Sandbox hardening follow-up — design-only
+milestone: v0.2
+priority: low
+status: open
+type: docs
+labels: [thumbnails, phase-15, security, sandbox, design-only]
+depends_on: []
+blocks: []
+assigned_agent_type: feature-dev:code-explorer
+estimated_complexity: small
+---
+
+# STRG-344: Sandbox hardening follow-up — design-only
+
+## Summary
+
+A design-only issue: produce a written threat-model + mitigation-options document for sandboxing image (and future PDF/Office) thumbnail generation. **No code is written under this issue.** The deliverable is a document under `docs/architecture/` that lays out the runway for the actual hardening work.
+
+## Background / Context
+
+Decision **D14** of issue #52 chose **in-process** safeguards for v1 (pixel cap + timeout + max-source-size, see STRG-338). This is sufficient against known image bombs but is NOT a mitigation against:
+
+1. A 0-day in libheif / libwebp / libtiff / Magick.NET / ImageMagick that escapes the pixel-cap (e.g., heap overflow during header parse before our probe completes).
+2. Future PDF/Office support (Phase 16) which dramatically widens the attack surface — PDFium, libreoffice, Docnet are all complex, network-aware, and historically CVE-rich.
+
+Process isolation is the right answer; v1 doesn't ship it because it's a multi-week investment and the current safeguards bound the blast radius adequately. STRG-344 captures the design so the next engineer (likely after the first image-library CVE bites in 2027) can move quickly.
+
+This issue is intentionally **design-only**, deliverable is documentation. The actual implementation will be a future issue (numbered when scheduled).
+
+## Technical Specification
+
+### Deliverable — `docs/architecture/07-thumbnail-sandboxing.md`
+
+YAML frontmatter:
+
+```yaml
+---
+title: "Thumbnail Sandboxing — Threat Model & Options"
+tags: [architecture, thumbnails, security, design-only]
+status: design
+created: 2026-05-01
+updated: 2026-05-01
+---
+```
+
+### Required sections
+
+1. **Scope** — what's covered (image generation, future PDF/Office) and what isn't (storage providers, GraphQL parsing, etc.).
+
+2. **Threat Model**
+
+   - **Attacker capability**: an authenticated tenant user who can upload arbitrary bytes (the upload endpoint validates MIME loosely; the consumer sniffs magic bytes but the decoder runs against attacker-controlled bytes).
+   - **In-flight assets**: the generator process, the database connection, the storage provider's blob credentials, sibling-tenant data on the same host.
+   - **Threat tree**:
+     - T1: RCE via decoder library (Magick.NET / libheif / libwebp / future libreoffice).
+     - T2: Resource exhaustion that bypasses the pixel-cap (e.g., a header that lies, or a decoder bug that allocates before our probe).
+     - T3: SSRF via decoder library that opens external resources (PDF embedded URLs, libreoffice document metadata fetches).
+     - T4: Filesystem access from a compromised generator (read other tenants' source files, write to the storage provider with the host's credentials).
+
+3. **Current Mitigations (in v1, in-process)**
+   - Pixel-cap + source-size + timeout (STRG-338).
+   - `MagickImage.Read(Stream)` (no path injection).
+   - `image.Strip()` (no metadata leak).
+   - Network egress: NOT currently restricted — generator runs in-process with the API host's egress rules. A `HttpClient` factory misuse from inside Magick.NET would have full egress.
+
+4. **Options for hardening** — table form:
+
+   | Option | Maturity | Cost | Pros | Cons |
+   |---|---|---|---|---|
+   | Dedicated worker process (sidecar, restricted FS + memory cgroups) | Production-grade | High (deployment + IPC + observability) | Strong isolation; OS-level enforcement; familiar to ops | Multi-process complicates container deployment; need a stable IPC contract |
+   | Per-generation Docker exec (one container per thumbnail) | Production-grade | Very high (container start latency, image hygiene) | Hardest isolation; clean teardown | Container start ≫ image decode for small images; breaks the latency budget |
+   | Browser-style WebAssembly sandbox | Experimental | Very high | Pure-CPU sandbox; no FS / no network by default | No WASM build of Magick.NET / ImageMagick; would require a different image library |
+   | Linux seccomp filter inside same process | Medium | Medium (need to allow-list every syscall) | Cheap, no IPC | Tricky to maintain across libheif / libwebp upgrades; lockfile not portable to non-Linux |
+   | gVisor / Kata sandboxed runtime at the host | Production-grade (where supported) | Low (operator-side) | Transparent to the app; works for any container | Operator-only; can't enforce in upstream code |
+
+5. **Recommended sequencing**
+   - **Now**: keep in-process. No work.
+   - **Trigger 1** — first CVE in `libheif` / `libwebp` / `Magick.NET` that escapes the pixel-cap or causes RCE: ship the **dedicated worker process** option. Estimated 2-3 engineer-weeks.
+   - **Trigger 2** — Phase 16 (PDF/Office) lands: re-evaluate; the broader attack surface may make the dedicated worker urgent.
+   - **Always**: document the runtime version of Magick.NET + libheif in observability so the operator knows when an advisory applies.
+
+6. **What NOT to do**
+   - Don't run the generator as root or with elevated capabilities.
+   - Don't pass `IStorageProvider` credentials to a sandboxed process — give it ONLY the source bytes and let the parent process write the result.
+   - Don't add a `Magick.NET` resource cap silently — the global `ResourceLimits` is process-wide and would affect every other Magick.NET caller (there are none today, but future plugins might collide).
+
+7. **Open questions** (for the future implementer)
+   - IPC: protobuf-over-stdin/stdout, gRPC, or shared memory?
+   - Worker-process language: also .NET (uniform), or Rust (smaller surface, no GC stalls)?
+   - Pool warmth: pre-fork worker pool vs. on-demand (latency tradeoff)?
+
+## Acceptance Criteria
+
+- [ ] `docs/architecture/07-thumbnail-sandboxing.md` exists with the YAML frontmatter and all seven required sections.
+- [ ] Threat tree (T1–T4) is enumerated with concrete examples.
+- [ ] Mitigation table compares at least the five options listed.
+- [ ] "Recommended sequencing" gives a clear "what to do now / what to do on trigger".
+- [ ] No code in this issue.
+
+## Test Cases
+
+- **TC-001**: A future engineer reading only this document can answer: "What attack are we actually defending against?", "What did v1 ship?", and "What's the cheapest next mitigation?"
+
+## Implementation Tasks
+
+- [ ] Write `docs/architecture/07-thumbnail-sandboxing.md` per the spec above.
+- [ ] Internal review with someone outside the thumbnail tranche (cold reader catches missing context).
+
+## Security Review Checklist
+
+- [ ] Document does not enumerate strg-specific exploit chains in a publishable form (this is a public repo). Threat-tree should describe class-of-attack, not "here's how to compromise our host today".
+- [ ] No internal infrastructure leakage (no host names, no AWS account IDs).
+
+## Code Review Checklist
+
+- [ ] Frontmatter matches existing ADR style.
+- [ ] H1 + H2-only structure.
+- [ ] Tables format consistently.
+
+## Definition of Done
+
+- [ ] Document published.
+- [ ] Linked from the main thumbnail ADR (`docs/architecture/06-thumbnails.md`) under "Resource Safeguards" → "see 07-thumbnail-sandboxing.md for the long-term plan".

--- a/src/Strg.Api/Endpoints/ThumbnailEndpoints.cs
+++ b/src/Strg.Api/Endpoints/ThumbnailEndpoints.cs
@@ -1,0 +1,170 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Net.Http.Headers;
+using Strg.Api.Auth;
+using Strg.Core.Domain;
+using Strg.Core.Services;
+using Strg.Infrastructure.Data;
+using Strg.Plugin.Abstractions.Storage;
+
+namespace Strg.Api.Endpoints;
+
+/// <summary>
+/// STRG-339 — REST endpoint for thumbnails. Streams the WebP blob from
+/// <see cref="IStorageProvider"/>, sets a strong content-addressed ETag
+/// (<c>ContentHash + Variant + Format</c>) with <c>Cache-Control: private, immutable</c>,
+/// and returns 304 / 202 / 404 per the status matrix.
+///
+/// <para><b>Auth.</b> Same <c>FilesRead</c> policy as the download endpoint — readers of the
+/// file already have the right to its thumbnail. The fall-through behaviour relies on the
+/// global tenant query filter: cross-tenant <c>fileId</c> lookups return null and produce 404.</para>
+///
+/// <para><b>Cache.</b> Cache-Control is <c>private</c> (browser cache OK, shared cache NO) so a
+/// CDN cannot accidentally serve the same path across tenants if a fileId GUID ever collided.
+/// <c>immutable</c> + <c>max-age=31536000</c> tells the browser to never revalidate within the
+/// year — safe because the ETag changes whenever <c>FileVersion.ContentHash</c> changes (new
+/// version) and old versions retain their old key indefinitely.</para>
+/// </summary>
+public static class ThumbnailEndpoints
+{
+    public const string EndpointName = "GetFileThumbnail";
+
+    private const string CacheControlValue = "private, max-age=31536000, immutable";
+    private const string ContentTypeWebP = "image/webp";
+
+    public static IEndpointRouteBuilder MapThumbnailEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/v1/drives/{driveId:guid}/files/{fileId:guid}/thumbnail", GetAsync)
+            .RequireAuthorization(AuthPolicies.FilesRead)
+            .WithName(EndpointName);
+
+        return app;
+    }
+
+    private static async Task<IResult> GetAsync(
+        HttpContext ctx,
+        Guid driveId,
+        Guid fileId,
+        string variant,
+        StrgDbContext db,
+        IThumbnailRepository thumbnails,
+        IDriveRepository driveRepo,
+        IStorageProviderRegistry storageRegistry,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(variant) || !ThumbnailVariants.IsKnown(variant))
+        {
+            return Results.BadRequest(new { error = "unknown-variant", variant });
+        }
+
+        // Resolve via the file repository's tenant filter — a cross-tenant fileId returns null
+        // and we report 404 without leaking existence.
+        var file = await db.Files
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == fileId && f.DriveId == driveId, cancellationToken)
+            .ConfigureAwait(false);
+        if (file is null)
+        {
+            return Results.NotFound();
+        }
+
+        // Latest version. The thumbnail row is keyed on the FileVersionId so we always serve
+        // the version's thumbnail for the latest file content.
+        var version = await db.FileVersions
+            .AsNoTracking()
+            .Where(v => v.FileId == fileId)
+            .OrderByDescending(v => v.VersionNumber)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (version is null)
+        {
+            return Results.NotFound();
+        }
+
+        var entry = await thumbnails.GetAsync(version.Id, variant, ThumbnailFormats.WebP, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entry is null)
+        {
+            // Consumer hasn't fired yet — common right after upload.
+            ctx.Response.Headers["Retry-After"] = "5";
+            return Results.StatusCode(StatusCodes.Status202Accepted);
+        }
+
+        return entry.Status switch
+        {
+            ThumbnailStatus.Pending => AcceptedWithRetry(ctx),
+            ThumbnailStatus.Failed or ThumbnailStatus.Unsupported => Results.NotFound(),
+            ThumbnailStatus.Ready => await StreamReadyAsync(
+                ctx, entry, version, driveRepo, storageRegistry, cancellationToken).ConfigureAwait(false),
+            _ => Results.StatusCode(StatusCodes.Status500InternalServerError),
+        };
+    }
+
+    private static IResult AcceptedWithRetry(HttpContext ctx)
+    {
+        ctx.Response.Headers["Retry-After"] = "5";
+        return Results.StatusCode(StatusCodes.Status202Accepted);
+    }
+
+    private static async Task<IResult> StreamReadyAsync(
+        HttpContext ctx,
+        ThumbnailEntry entry,
+        FileVersion version,
+        IDriveRepository driveRepo,
+        IStorageProviderRegistry storageRegistry,
+        CancellationToken cancellationToken)
+    {
+        // Strong ETag is content-addressed: same file content → same ContentHash → same ETag.
+        // Quoted per RFC 7232 §2.3.
+        var etag = $"\"{version.ContentHash}-{entry.Variant}-{entry.Format}\"";
+
+        // If-None-Match exact match → 304. Stream is not opened.
+        if (ctx.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatch)
+            && ifNoneMatch.Any(v => string.Equals(v, etag, StringComparison.Ordinal)))
+        {
+            ctx.Response.Headers[HeaderNames.ETag] = etag;
+            ctx.Response.Headers[HeaderNames.CacheControl] = CacheControlValue;
+            return Results.StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        // Drive comes from the route — every thumbnail lives on the same drive as its source.
+        var driveId = ctx.Request.RouteValues["driveId"] is Guid did ? did : Guid.Empty;
+        var drive = await driveRepo.GetByIdAsync(driveId, cancellationToken).ConfigureAwait(false);
+        if (drive is null)
+        {
+            return Results.NotFound();
+        }
+
+        var provider = ResolveProvider(drive, storageRegistry);
+        var path = StoragePath.Parse(entry.StorageKey);
+        var stream = await provider.ReadAsync(path.Value, 0, cancellationToken).ConfigureAwait(false);
+
+        ctx.Response.Headers[HeaderNames.ETag] = etag;
+        ctx.Response.Headers[HeaderNames.CacheControl] = CacheControlValue;
+        ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
+
+        var contentType = entry.Format == ThumbnailFormats.Jpeg
+            ? "image/jpeg"
+            : ContentTypeWebP;
+
+        return Results.File(stream, contentType: contentType, enableRangeProcessing: false);
+    }
+
+    private static IStorageProvider ResolveProvider(Drive drive, IStorageProviderRegistry registry)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        using var json = System.Text.Json.JsonDocument.Parse(drive.ProviderConfig);
+        foreach (var property in json.RootElement.EnumerateObject())
+        {
+            values[property.Name] = property.Value.ValueKind switch
+            {
+                System.Text.Json.JsonValueKind.String => property.Value.GetString(),
+                System.Text.Json.JsonValueKind.Null => null,
+                _ => property.Value.GetRawText(),
+            };
+        }
+        var config = new DictionaryStorageProviderConfig(values);
+        return registry.Resolve(drive.ProviderType, config);
+    }
+}

--- a/src/Strg.Api/Program.cs
+++ b/src/Strg.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Serilog;
 using StackExchange.Redis;
 using Strg.Api.Auth;
@@ -36,6 +37,8 @@ using Strg.Infrastructure.Messaging;
 using Strg.Infrastructure.Observability;
 using Strg.Infrastructure.Services;
 using Strg.Infrastructure.Storage;
+using Strg.Infrastructure.Thumbnails;
+using Strg.Infrastructure.Thumbnails.Generators;
 using Strg.Infrastructure.Upload;
 using Strg.Infrastructure.Versioning;
 using Strg.WebDav;
@@ -99,6 +102,21 @@ builder.Services.AddScoped<IQuotaService>(sp => sp.GetRequiredService<QuotaServi
 builder.Services.AddScoped<IQuotaAdminService>(sp => sp.GetRequiredService<QuotaService>());
 builder.Services.AddScoped<IFileVersionStore, FileVersionStore>();
 builder.Services.AddScoped<ITagRepository, TagRepository>();
+
+// ---- Thumbnails (STRG-329..STRG-344) ----
+// Generators registered as singletons (Magick.NET image instances are short-lived inside
+// GenerateAsync; the generator itself is stateless). Service + repository scoped so the
+// per-consume DbContext flows through. Options validated at startup — invalid config crashes
+// the host instead of failing on first generation.
+builder.Services
+    .AddOptions<ThumbnailOptions>()
+    .Bind(builder.Configuration.GetSection(ThumbnailOptions.SectionName))
+    .ValidateOnStart();
+builder.Services.AddSingleton<IValidateOptions<ThumbnailOptions>, ThumbnailOptionsValidator>();
+builder.Services.AddSingleton<IThumbnailGenerator, MagickNetImageThumbnailer>();
+builder.Services.AddSingleton<IThumbnailGeneratorRegistry, ThumbnailGeneratorRegistry>();
+builder.Services.AddScoped<IThumbnailRepository, ThumbnailRepository>();
+builder.Services.AddScoped<IThumbnailService, ThumbnailService>();
 
 // STRG-034 — TUS upload pipeline. StrgTusStore creates a fresh StrgDbContext per method (via
 // injected DbContextOptions) because tusdotnet's validation pipeline can interleave read calls
@@ -224,6 +242,11 @@ builder.Services.AddStrgMassTransit(
     {
         bus.AddConsumer<Strg.GraphQl.Consumers.GraphQlSubscriptionPublisher>();
         bus.AddConsumer<Strg.WebDav.Consumers.WebDavJwtCacheInvalidationConsumer>();
+        // STRG-331/332/341 — thumbnail consumers + dead-letter observer. Tenant is read from
+        // event payload, not ambient context (consumer scope has empty ITenantContext).
+        bus.AddConsumer<Strg.Infrastructure.Messaging.Consumers.ThumbnailGenerationConsumer>();
+        bus.AddConsumer<Strg.Infrastructure.Messaging.Consumers.ThumbnailGenerationFaultObserver>();
+        bus.AddConsumer<Strg.Infrastructure.Messaging.Consumers.ThumbnailCleanupConsumer>();
     });
 
 // ---- Authorization policies (STRG-013) ----
@@ -282,6 +305,10 @@ var graphql = builder.Services
     .AddType<DriveByIdDataLoader>()
     .AddType<UserByIdDataLoader>()
     .AddType<InboxRuleByIdDataLoader>()
+    .AddType<Strg.GraphQl.DataLoaders.ThumbnailDataLoader>()
+    .AddType<Strg.GraphQl.Types.ThumbnailType>()
+    .AddType<Strg.GraphQl.Subscriptions.ThumbnailSubscriptions>()
+    .AddType<Strg.GraphQl.Mutations.Admin.RegenerateThumbnailsMutationHandlers>()
     .AddGlobalObjectIdentification()
     .AddFiltering()
     .AddSorting()
@@ -442,6 +469,9 @@ app.MapFileVersionEndpoints();
 app.MapFolderCreateEndpoints();
 app.MapUserRegistrationEndpoints();
 app.MapUserEndpoints();
+// STRG-339 — thumbnail GET endpoint with ETag/304/202-pending. Same FilesRead policy as the
+// download endpoint: a reader of a file owns access to its thumbnail.
+app.MapThumbnailEndpoints();
 
 // STRG-034 — TUS upload endpoint. Mapped after UseAuthentication/UseAuthorization (line 352-353)
 // so HttpContext.User is populated before OnAuthorizeAsync runs. .RequireAuthorization() is

--- a/src/Strg.Api/appsettings.json
+++ b/src/Strg.Api/appsettings.json
@@ -29,5 +29,15 @@
     "Global": { "PermitLimit": 300, "WindowSeconds": 60, "QueueLimit": 0 },
     "Upload": { "PermitLimit": 100, "WindowSeconds": 60, "QueueLimit": 0 }
   },
+  "Thumbnails": {
+    "Enabled": true,
+    "Variants": [ "thumb", "small", "medium" ],
+    "MaxSourceSizeBytes": 268435456,
+    "MaxPixelArea": 100000000,
+    "GenerationTimeoutSeconds": 30,
+    "WebPQuality": 82,
+    "PdfEnabled": true,
+    "OfficeEnabled": false
+  },
   "Plugins": []
 }

--- a/src/Strg.Core/Domain/IThumbnailRepository.cs
+++ b/src/Strg.Core/Domain/IThumbnailRepository.cs
@@ -1,0 +1,46 @@
+namespace Strg.Core.Domain;
+
+/// <summary>
+/// Persistence port for <see cref="ThumbnailEntry"/>. Per project convention, repositories DO
+/// NOT call <c>SaveChangesAsync</c> — the caller (consumer / endpoint handler) commits.
+/// </summary>
+public interface IThumbnailRepository
+{
+    /// <summary>Stages a new entry for insertion. Caller commits.</summary>
+    void Add(ThumbnailEntry entry);
+
+    /// <summary>
+    /// Returns the row matching <c>(fileVersionId, variant, format)</c> or <c>null</c>. Used by
+    /// the REST endpoint to resolve a request and by the consumer to detect a re-delivery's
+    /// pre-existing row after a <c>23505</c> catch.
+    /// </summary>
+    Task<ThumbnailEntry?> GetAsync(
+        Guid fileVersionId,
+        string variant,
+        string format,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns every row for a given <see cref="FileVersion"/>. Used by the REST endpoint's
+    /// fallback path (when a specific variant is missing but others may exist) and by the
+    /// extended <c>PruneVersionsAsync</c> loop to enumerate blob keys before transactional row removal.
+    /// </summary>
+    Task<IReadOnlyList<ThumbnailEntry>> GetByFileVersionAsync(
+        Guid fileVersionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns every row for a given <see cref="FileItem"/> (across all its versions). Used by
+    /// <c>ThumbnailCleanupConsumer</c> on <c>FileDeletedEvent</c>.
+    /// </summary>
+    Task<IReadOnlyList<ThumbnailEntry>> GetByFileAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Marks each entry's <see cref="TenantedEntity.DeletedAt"/>. Caller commits.
+    /// Idempotent: re-applying to already-soft-deleted rows is a no-op (the global filter
+    /// excludes them so the input list itself never contains them on re-delivery).
+    /// </summary>
+    void SoftDeleteRange(IEnumerable<ThumbnailEntry> entries);
+}

--- a/src/Strg.Core/Domain/ThumbnailEntry.cs
+++ b/src/Strg.Core/Domain/ThumbnailEntry.cs
@@ -1,0 +1,71 @@
+namespace Strg.Core.Domain;
+
+/// <summary>
+/// One row per generated thumbnail blob. Carries the variant/format coordinate, the storage
+/// key the blob is at, and a lifecycle <see cref="ThumbnailStatus"/>.
+///
+/// <para><b>Idempotency.</b> The unique constraint <c>(FileVersionId, Variant, Format)</c>
+/// (pinned name <c>ThumbnailConstraintNames.UniqueIndex</c> in Strg.Infrastructure) is the
+/// load-bearing key for at-least-once redelivery. <c>ThumbnailGenerationConsumer</c> catches
+/// the SQLSTATE 23505 + exact <c>ConstraintName</c> equality and treats it as "row already
+/// landed on a prior delivery — no-op".</para>
+///
+/// <para><b>Tenant scoping.</b> Inherits <see cref="TenantedEntity"/>'s global query filter on
+/// <c>TenantId</c> + <c>DeletedAt</c>. The consumer must populate <see cref="TenantedEntity.TenantId"/>
+/// from the event payload — never from the (empty) ambient <c>ITenantContext</c> in consumer
+/// scope. Cleanup soft-deletes via <see cref="TenantedEntity.DeletedAt"/>; the global filter
+/// hides soft-deleted rows from regular queries.</para>
+///
+/// <para><b>Cascade.</b> The EF configuration sets <c>OnDelete(Cascade)</c> from
+/// <see cref="FileVersion"/> — pruning a version row physically removes its thumbnail rows.
+/// Blob cleanup is explicit (handled by <c>ThumbnailCleanupConsumer</c> on <c>FileDeletedEvent</c>
+/// and by <c>FileVersionStore.PruneVersionsAsync</c>'s extended per-version loop).</para>
+/// </summary>
+public sealed class ThumbnailEntry : TenantedEntity
+{
+    /// <summary>FK to <see cref="FileVersion.Id"/>. The only durable link from a thumbnail to its source bytes.</summary>
+    public required Guid FileVersionId { get; init; }
+
+    /// <summary>
+    /// FK to <see cref="FileItem.Id"/>. Denormalised from <c>FileVersion.FileId</c> so the cleanup
+    /// consumer can soft-delete every thumbnail for a file in one query without a join — the
+    /// <c>FileDeletedEvent</c> only carries the file id, and the per-version chain would force a
+    /// nested lookup that adds an avoidable round-trip on every delete.
+    /// </summary>
+    public required Guid FileId { get; init; }
+
+    /// <summary>One of the whitelisted strings in <c>ThumbnailVariants.All</c> (currently <c>thumb</c>, <c>small</c>, <c>medium</c>).</summary>
+    public required string Variant { get; init; }
+
+    /// <summary>Output format (<c>webp</c> in v1; <c>jpeg</c> reserved for fallback).</summary>
+    public required string Format { get; init; }
+
+    /// <summary>
+    /// Storage key for the blob (e.g. <c>thumbnails/{driveId}/{fileVersionId}/small.webp</c>).
+    /// Empty until <see cref="Status"/> reaches <see cref="ThumbnailStatus.Ready"/>; never
+    /// concatenated by callers — always built via <c>ThumbnailStorageKeyBuilder.Build</c> and
+    /// wrapped in <c>StoragePath.Parse</c> before reaching <c>IStorageProvider</c>.
+    /// </summary>
+    public string StorageKey { get; set; } = string.Empty;
+
+    public long SizeBytes { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+
+    public ThumbnailStatus Status { get; set; } = ThumbnailStatus.Pending;
+
+    /// <summary>
+    /// Bounded human-readable reason for non-<c>Ready</c> states. Capped at 256 chars in EF
+    /// configuration so adversarial inputs cannot blow up the audit/log surface.
+    /// </summary>
+    public string? ErrorReason { get; set; }
+
+    public DateTimeOffset? GeneratedAt { get; set; }
+
+    /// <summary>
+    /// Stable identifier for the generator (and its tunable knobs) that produced this row.
+    /// Not wired to any auto-regeneration trigger today — exists so a future bump-and-regen
+    /// admin action can target rows by version without scanning blob bytes.
+    /// </summary>
+    public required string GeneratorVersion { get; init; }
+}

--- a/src/Strg.Core/Domain/ThumbnailStatus.cs
+++ b/src/Strg.Core/Domain/ThumbnailStatus.cs
@@ -1,0 +1,19 @@
+namespace Strg.Core.Domain;
+
+/// <summary>
+/// Lifecycle state for a <see cref="ThumbnailEntry"/>. The four states are mutually exclusive
+/// per (FileVersion, Variant, Format) tuple and govern how the REST/GraphQL surfaces respond:
+/// <list type="bullet">
+///   <item><c>Pending</c> — row inserted by the consumer; blob not yet written. REST returns 202.</item>
+///   <item><c>Ready</c> — blob written and metadata populated. REST streams 200; ETag is strong.</item>
+///   <item><c>Failed</c> — generator threw or timed out. REST returns 404 (no blob exists). Retryable via backfill.</item>
+///   <item><c>Unsupported</c> — the source MIME / safeguard / encrypted-drive carve-out forbids generation. REST returns 404.</item>
+/// </list>
+/// </summary>
+public enum ThumbnailStatus
+{
+    Pending = 0,
+    Ready = 1,
+    Failed = 2,
+    Unsupported = 3,
+}

--- a/src/Strg.Core/Events/ThumbnailGenerationRequestedEvent.cs
+++ b/src/Strg.Core/Events/ThumbnailGenerationRequestedEvent.cs
@@ -1,0 +1,19 @@
+using Strg.Core.Domain;
+
+namespace Strg.Core.Events;
+
+/// <summary>
+/// Backfill trigger published by the admin <c>regenerateThumbnails</c> mutation. Consumed by
+/// <c>ThumbnailGenerationConsumer</c> via the same shared orchestration as
+/// <c>FileUploadedEvent</c>.
+///
+/// <para><b>Dedicated event, not republished <c>FileUploadedEvent</c>.</b> Republishing the
+/// upload event would double-write <c>AuditEntry</c> rows via <c>AuditLogConsumer</c>. The
+/// dedicated event has no audit consumer; only the thumbnail generation consumer subscribes
+/// to it.</para>
+/// </summary>
+public sealed record ThumbnailGenerationRequestedEvent(
+    Guid TenantId,
+    Guid FileId,
+    Guid FileVersionId,
+    Guid DriveId) : IDomainEvent;

--- a/src/Strg.Core/Events/ThumbnailReadyEvent.cs
+++ b/src/Strg.Core/Events/ThumbnailReadyEvent.cs
@@ -1,0 +1,20 @@
+using Strg.Core.Domain;
+
+namespace Strg.Core.Events;
+
+/// <summary>
+/// Published by <c>ThumbnailGenerationConsumer</c> after a per-variant blob successfully lands
+/// at <see cref="ThumbnailStatus.Ready"/>. Consumed by <c>GraphQlSubscriptionPublisher</c> to
+/// push the live <c>thumbnailReady(fileId)</c> subscription payload.
+///
+/// <para>Outbox-published BEFORE <c>SaveChangesAsync</c> on the row update so the event and
+/// the state change commit atomically.</para>
+/// </summary>
+public sealed record ThumbnailReadyEvent(
+    Guid TenantId,
+    Guid FileId,
+    Guid FileVersionId,
+    string Variant,
+    string Format,
+    int Width,
+    int Height) : IDomainEvent;

--- a/src/Strg.Core/Services/IThumbnailGenerator.cs
+++ b/src/Strg.Core/Services/IThumbnailGenerator.cs
@@ -1,0 +1,77 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// Generator-agnostic request envelope passed to <see cref="IThumbnailGenerator.GenerateAsync"/>.
+/// Contains everything the generator needs to size + format the output without re-resolving
+/// configuration.
+/// </summary>
+public sealed record ThumbnailRequest(
+    string Variant,
+    int TargetEdgePixels,
+    string TargetFormat,
+    long SourceSizeBytes,
+    string SourceMimeType);
+
+/// <summary>
+/// Sum-type result from <see cref="IThumbnailGenerator.GenerateAsync"/>. Each shape maps to a
+/// different <see cref="Domain.ThumbnailStatus"/> + metric reason in the consumer. Failure
+/// modes are NOT exceptions — consumer code branches deterministically on the case.
+/// </summary>
+public abstract record ThumbnailGenerationOutcome
+{
+    /// <summary>
+    /// Generation succeeded. <see cref="Output"/> is owned by the caller (consumer disposes via
+    /// <c>await using</c> after writing to <c>IStorageProvider</c>).
+    /// </summary>
+    public sealed record Success(Stream Output, int Width, int Height, string Format)
+        : ThumbnailGenerationOutcome;
+
+    /// <summary>The generator does not handle this MIME / extension after a closer look.</summary>
+    public sealed record Unsupported(string Reason) : ThumbnailGenerationOutcome;
+
+    /// <summary>The source bytes failed to decode (truncated, malformed, or library-bug shape).</summary>
+    public sealed record SourceCorrupt(string Reason) : ThumbnailGenerationOutcome;
+
+    /// <summary>The source exceeded a configured limit (e.g. pixel-area cap).</summary>
+    public sealed record ResourceLimitExceeded(string Reason) : ThumbnailGenerationOutcome;
+
+    /// <summary>The per-call timeout fired before the generator finished.</summary>
+    public sealed record TimedOut(TimeSpan Limit) : ThumbnailGenerationOutcome;
+}
+
+/// <summary>
+/// A thumbnail-format-specific generator (image, PDF, Office). Generators self-declare via
+/// <see cref="CanHandle"/> so the consumer never branches on MIME — new generators (Phase 16)
+/// plug into the registry without consumer/API/DB changes.
+///
+/// <para>v1 ships exactly one generator (Magick.NET for raster images). Phase 16 adds PDFium
+/// and LibreOffice generators behind the same contract.</para>
+/// </summary>
+public interface IThumbnailGenerator
+{
+    /// <summary>
+    /// Stable identifier for the generator (e.g. <c>"magick-net-q8"</c>) — written into
+    /// <c>ThumbnailEntry.GeneratorVersion</c> so a future bump-and-regen admin action can target
+    /// rows by generator without inspecting blob bytes.
+    /// </summary>
+    string Version { get; }
+
+    /// <summary>
+    /// True when this generator can produce a thumbnail for the source described by
+    /// <paramref name="mimeType"/> + <paramref name="magicBytes"/> (first ~16 bytes of the
+    /// source). Implementations are encouraged to consult both — <see cref="MimeSniffer"/>
+    /// is conservative and may return a generic MIME for some formats.
+    /// </summary>
+    bool CanHandle(string mimeType, ReadOnlySpan<byte> magicBytes);
+
+    /// <summary>
+    /// Generate one thumbnail for <paramref name="request"/>. <paramref name="source"/> is read
+    /// from start; the implementation MUST stream end-to-end where the underlying library
+    /// permits (no full <c>byte[]</c> buffering of the source). The returned
+    /// <see cref="ThumbnailGenerationOutcome.Success"/> stream is owned by the caller.
+    /// </summary>
+    Task<ThumbnailGenerationOutcome> GenerateAsync(
+        Stream source,
+        ThumbnailRequest request,
+        CancellationToken cancellationToken);
+}

--- a/src/Strg.Core/Services/IThumbnailGeneratorRegistry.cs
+++ b/src/Strg.Core/Services/IThumbnailGeneratorRegistry.cs
@@ -1,0 +1,15 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// First-registered-match-wins resolver over all <see cref="IThumbnailGenerator"/> registrations.
+/// Mirrors the <c>IStorageProviderRegistry</c> shape so consumers stay generator-agnostic.
+/// </summary>
+public interface IThumbnailGeneratorRegistry
+{
+    /// <summary>
+    /// Returns the first registered generator whose <see cref="IThumbnailGenerator.CanHandle"/>
+    /// returns true for <paramref name="mimeType"/> + <paramref name="magicBytes"/>, or
+    /// <c>null</c> when no generator self-declared support.
+    /// </summary>
+    IThumbnailGenerator? Resolve(string mimeType, ReadOnlySpan<byte> magicBytes);
+}

--- a/src/Strg.Core/Services/IThumbnailService.cs
+++ b/src/Strg.Core/Services/IThumbnailService.cs
@@ -1,0 +1,28 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// Orchestrator surface the consumer talks to. Fans out to N <see cref="IThumbnailGenerator"/>
+/// invocations (one per requested variant) and writes the resulting <see cref="Domain.ThumbnailEntry"/>
+/// rows + blobs.
+///
+/// <para><b>Why an indirection?</b> <c>ThumbnailGenerationConsumer</c> handles two event types
+/// (<c>FileUploadedEvent</c> + <c>ThumbnailGenerationRequestedEvent</c>) that share identical
+/// orchestration but differ in payload shape. The service hides the per-variant fan-out and
+/// idempotency logic from the consumer's two <c>Consume</c> entrypoints.</para>
+/// </summary>
+public interface IThumbnailService
+{
+    /// <summary>
+    /// Generate every variant in <paramref name="variants"/> for the file at
+    /// <paramref name="fileVersionId"/>. Idempotent: a re-delivery finds the rows already at
+    /// <see cref="Domain.ThumbnailStatus.Ready"/> / <see cref="Domain.ThumbnailStatus.Unsupported"/>
+    /// and returns without re-running the generator.
+    /// </summary>
+    Task GenerateAllAsync(
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        Guid driveId,
+        IReadOnlyList<string> variants,
+        CancellationToken cancellationToken);
+}

--- a/src/Strg.Core/Services/MimeSniffer.cs
+++ b/src/Strg.Core/Services/MimeSniffer.cs
@@ -1,0 +1,75 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// Whitelist-only magic-byte sniffer that maps the first few bytes of a file to a canonical
+/// IANA MIME type. NOT a libmagic substitute — the whitelist is intentionally narrow:
+/// formats we generate thumbnails for in v1 (JPEG, PNG, GIF, WebP, HEIC) plus PDF (no v1
+/// generator, but the registry self-declares miss → <c>Unsupported</c>; Phase 16 ships the
+/// PDF generator without re-touching this file).
+///
+/// <para><b>Why sniff at thumbnail time.</b> <see cref="Domain.FileItem.MimeType"/> is
+/// client-provided at upload — the client can lie. Sniffing here ensures the generator we
+/// resolve is actually appropriate for the bytes we're about to feed it (D12).</para>
+///
+/// <para>Truncated input (less than the format's signature length) returns <c>null</c>;
+/// callers handle this as "unknown MIME → write Unsupported row".</para>
+/// </summary>
+public static class MimeSniffer
+{
+    /// <summary>Inspect <paramref name="head"/> (first ~16 bytes is sufficient) and return the canonical MIME, or <c>null</c>.</summary>
+    public static string? Detect(ReadOnlySpan<byte> head)
+    {
+        // JPEG: FF D8 FF
+        if (head.Length >= 3 && head[0] == 0xFF && head[1] == 0xD8 && head[2] == 0xFF)
+        {
+            return "image/jpeg";
+        }
+
+        // PNG: 89 50 4E 47 0D 0A 1A 0A
+        if (head.Length >= 8 &&
+            head[0] == 0x89 && head[1] == 0x50 && head[2] == 0x4E && head[3] == 0x47 &&
+            head[4] == 0x0D && head[5] == 0x0A && head[6] == 0x1A && head[7] == 0x0A)
+        {
+            return "image/png";
+        }
+
+        // GIF: "GIF87a" or "GIF89a"
+        if (head.Length >= 6 &&
+            head[0] == 0x47 && head[1] == 0x49 && head[2] == 0x46 && head[3] == 0x38 &&
+            (head[4] == 0x37 || head[4] == 0x39) && head[5] == 0x61)
+        {
+            return "image/gif";
+        }
+
+        // WebP: "RIFF" .... "WEBP" (offset 8)
+        if (head.Length >= 12 &&
+            head[0] == 0x52 && head[1] == 0x49 && head[2] == 0x46 && head[3] == 0x46 &&
+            head[8] == 0x57 && head[9] == 0x45 && head[10] == 0x42 && head[11] == 0x50)
+        {
+            return "image/webp";
+        }
+
+        // PDF: "%PDF-"
+        if (head.Length >= 5 &&
+            head[0] == 0x25 && head[1] == 0x50 && head[2] == 0x44 && head[3] == 0x46 && head[4] == 0x2D)
+        {
+            return "application/pdf";
+        }
+
+        // HEIC/HEIF: bytes 4..7 = "ftyp", brand at 8..11 in the recognised set.
+        if (head.Length >= 12 &&
+            head[4] == 0x66 && head[5] == 0x74 && head[6] == 0x79 && head[7] == 0x70)
+        {
+            // ASCII brand at offset 8, 4 chars.
+            var brand = (char)head[8] + "" + (char)head[9] + (char)head[10] + (char)head[11];
+            return brand switch
+            {
+                "heic" or "heix" or "heim" or "heis" or "hevc" or "hevx" => "image/heic",
+                "mif1" or "msf1" => "image/heif",
+                _ => null,
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/Strg.Core/Services/ThumbnailStorageKeyBuilder.cs
+++ b/src/Strg.Core/Services/ThumbnailStorageKeyBuilder.cs
@@ -1,0 +1,48 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// Centralised builder for thumbnail storage keys. The format
+/// <c>thumbnails/{driveId}/{fileVersionId}/{variant}.{format}</c> is the single source of truth —
+/// callers MUST NOT concatenate strings. Same discipline as <c>StorageKey</c> handling in the
+/// upload pipeline.
+///
+/// <para><b>Caller obligation.</b> The returned key is a logical path, not a sanitised
+/// <c>StoragePath</c>. Every call site MUST wrap the result in <c>StoragePath.Parse(...)</c>
+/// before passing it to <c>IStorageProvider</c>. The generator's input variants come from a
+/// closed whitelist (<see cref="ThumbnailVariants.IsKnown"/>) but defence-in-depth applies —
+/// path-traversal protection lives at the storage boundary.</para>
+/// </summary>
+public static class ThumbnailStorageKeyBuilder
+{
+    /// <summary>
+    /// Build the canonical storage key for a thumbnail blob.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="driveId"/> or <paramref name="fileVersionId"/> is <see cref="Guid.Empty"/>;
+    /// <paramref name="variant"/> is not in <see cref="ThumbnailVariants.All"/>;
+    /// <paramref name="format"/> is not in the known formats whitelist.
+    /// </exception>
+    public static string Build(Guid driveId, Guid fileVersionId, string variant, string format)
+    {
+        if (driveId == Guid.Empty)
+        {
+            throw new ArgumentException("Drive id must not be empty.", nameof(driveId));
+        }
+        if (fileVersionId == Guid.Empty)
+        {
+            throw new ArgumentException("File version id must not be empty.", nameof(fileVersionId));
+        }
+        if (!ThumbnailVariants.IsKnown(variant))
+        {
+            throw new ArgumentException(
+                $"Unknown thumbnail variant '{variant}'.", nameof(variant));
+        }
+        if (!ThumbnailFormats.IsKnown(format))
+        {
+            throw new ArgumentException(
+                $"Unknown thumbnail format '{format}'.", nameof(format));
+        }
+
+        return $"thumbnails/{driveId:D}/{fileVersionId:D}/{variant}.{format}";
+    }
+}

--- a/src/Strg.Core/Services/ThumbnailVariants.cs
+++ b/src/Strg.Core/Services/ThumbnailVariants.cs
@@ -1,0 +1,45 @@
+namespace Strg.Core.Services;
+
+/// <summary>
+/// Static catalogue of thumbnail variant identifiers + their pixel-edge sizes. String constants
+/// (not <c>enum</c>) so future operator-tunable variants (config-driven via <c>ThumbnailOptions</c>)
+/// don't force a code change; the database column is also <c>varchar</c> so the wire format
+/// stays stable across deploys.
+/// </summary>
+public static class ThumbnailVariants
+{
+    public const string Thumb = "thumb";
+    public const string Small = "small";
+    public const string Medium = "medium";
+
+    /// <summary>
+    /// Square edge length in pixels for each variant. The image generator resizes the longest
+    /// edge to this and letterboxes the result onto a square canvas.
+    /// </summary>
+    public static int EdgePixelsFor(string variant) => variant switch
+    {
+        Thumb => 256,
+        Small => 512,
+        Medium => 1024,
+        _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown thumbnail variant"),
+    };
+
+    /// <summary>The default variant set used by the generation consumer when no override is configured.</summary>
+    public static IReadOnlyList<string> All { get; } = [Thumb, Small, Medium];
+
+    /// <summary>True when <paramref name="variant"/> is in the <see cref="All"/> whitelist.</summary>
+    public static bool IsKnown(string variant) =>
+        variant == Thumb || variant == Small || variant == Medium;
+}
+
+/// <summary>
+/// Output formats the thumbnail subsystem can write. WebP is the v1 default (D9). JPEG is the
+/// reserved fallback for clients that cannot render WebP — not implemented in v1.
+/// </summary>
+public static class ThumbnailFormats
+{
+    public const string WebP = "webp";
+    public const string Jpeg = "jpeg";
+
+    public static bool IsKnown(string format) => format == WebP || format == Jpeg;
+}

--- a/src/Strg.GraphQl/Consumers/GraphQlSubscriptionPublisher.cs
+++ b/src/Strg.GraphQl/Consumers/GraphQlSubscriptionPublisher.cs
@@ -14,8 +14,18 @@ public sealed class GraphQlSubscriptionPublisher(ITopicEventSender sender, ILogg
         IConsumer<FileMovedEvent>,
         IConsumer<FileCopiedEvent>,
         IConsumer<FileRenamedEvent>,
-        IConsumer<QuotaWarningEvent>
+        IConsumer<QuotaWarningEvent>,
+        IConsumer<ThumbnailReadyEvent>
 {
+    public async Task Consume(ConsumeContext<ThumbnailReadyEvent> ctx)
+    {
+        var msg = ctx.Message;
+        var topic = Topics.ThumbnailReady(msg.TenantId, msg.FileId);
+        await sender.SendAsync(topic, msg, ctx.CancellationToken);
+        logger.LogDebug("Published ThumbnailReady ({Variant}/{Format}) for file {FileId} to topic {Topic}",
+            msg.Variant, msg.Format, msg.FileId, topic);
+    }
+
     public Task Consume(ConsumeContext<FileUploadedEvent> ctx)
         => SendAsync(FileEventType.Uploaded, ctx.Message.FileId, ctx.Message.DriveId,
             ctx.Message.UserId, ctx.Message.TenantId, null, null, ctx.CancellationToken);

--- a/src/Strg.GraphQl/DataLoaders/ThumbnailDataLoader.cs
+++ b/src/Strg.GraphQl/DataLoaders/ThumbnailDataLoader.cs
@@ -1,0 +1,95 @@
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Core.Services;
+using Strg.GraphQl.Types;
+using Strg.Infrastructure.Data;
+
+namespace Strg.GraphQl.DataLoaders;
+
+/// <summary>
+/// Composite key for the thumbnail DataLoader — every <c>FileItem.thumbnail(variant: …)</c>
+/// query in a single GraphQL request batches into one SQL fetch keyed on
+/// <see cref="FileId"/> + <see cref="Variant"/>.
+/// </summary>
+public readonly record struct ThumbnailKey(Guid FileId, string Variant);
+
+/// <summary>
+/// Batches thumbnail lookups across a single GraphQL request. Without this, a 50-row grid view
+/// querying <c>thumbnail(variant: SMALL)</c> on each row would issue 50 SQL round-trips against
+/// <c>ThumbnailEntries</c>. The DataLoader collapses to one query.
+///
+/// <para><b>Latest-version policy.</b> A thumbnail row is keyed on FileVersionId, but consumers
+/// of the GraphQL field always want the LATEST version's thumbnail. The batch query joins
+/// <c>FileVersions</c> and orders by <c>VersionNumber DESC</c>, picking the first hit per
+/// (FileId, Variant) pair.</para>
+/// </summary>
+public sealed class ThumbnailDataLoader(
+    IDbContextFactory<StrgDbContext> dbFactory,
+    IBatchScheduler batchScheduler,
+    LinkGenerator linkGenerator,
+    DataLoaderOptions? options = null)
+    : BatchDataLoader<ThumbnailKey, Thumbnail>(batchScheduler, options ?? new DataLoaderOptions())
+{
+    protected override async Task<IReadOnlyDictionary<ThumbnailKey, Thumbnail>> LoadBatchAsync(
+        IReadOnlyList<ThumbnailKey> keys,
+        CancellationToken cancellationToken)
+    {
+        var fileIds = keys.Select(k => k.FileId).Distinct().ToList();
+        var variants = keys.Select(k => k.Variant).Distinct().ToList();
+
+        await using var db = await dbFactory.CreateDbContextAsync(cancellationToken);
+
+        // Pull every candidate row + its FileVersion's VersionNumber so we can pick the latest.
+        // Format is fixed at "webp" in v1 — when JPEG fallback ships, this becomes a per-key
+        // filter ranked by client UA preference (out of v1 scope).
+        var rows = await (
+                from t in db.ThumbnailEntries
+                join v in db.FileVersions on t.FileVersionId equals v.Id
+                where fileIds.Contains(v.FileId)
+                      && variants.Contains(t.Variant)
+                      && t.Format == ThumbnailFormats.WebP
+                select new { v.FileId, v.VersionNumber, Entry = t, DriveId = v.FileId })
+            .ToListAsync(cancellationToken);
+
+        // For each (FileId, Variant), pick the row tied to the highest VersionNumber.
+        var picked = rows
+            .GroupBy(r => new ThumbnailKey(r.FileId, r.Entry.Variant))
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(r => r.VersionNumber).First().Entry);
+
+        // Need the file's DriveId to build the REST URL. Single round-trip; bounded by fileIds.
+        var driveIdByFile = await db.Files
+            .Where(f => fileIds.Contains(f.Id))
+            .Select(f => new { f.Id, f.DriveId })
+            .ToDictionaryAsync(x => x.Id, x => x.DriveId, cancellationToken);
+
+        return picked.ToDictionary(
+            kv => kv.Key,
+            kv => MapToGraphQl(
+                kv.Value,
+                driveIdByFile.TryGetValue(kv.Key.FileId, out var driveId) ? driveId : Guid.Empty));
+    }
+
+    private Thumbnail MapToGraphQl(ThumbnailEntry entry, Guid driveId)
+    {
+        var url = linkGenerator.GetPathByName(
+            "GetFileThumbnail",
+            new { driveId, fileId = entry.FileId })
+            ?? $"/api/v1/drives/{driveId}/files/{entry.FileId}/thumbnail";
+
+        // Append the variant query string. LinkGenerator omits query args by design.
+        var fullUrl = $"{url}?variant={Uri.EscapeDataString(entry.Variant)}";
+
+        var ready = entry.Status == ThumbnailStatus.Ready;
+        return new Thumbnail(
+            Url: fullUrl,
+            Width: ready ? entry.Width : null,
+            Height: ready ? entry.Height : null,
+            SizeBytes: ready ? entry.SizeBytes : null,
+            Status: ThumbnailStatusMap.FromDomain(entry.Status),
+            Format: ready ? entry.Format : null,
+            ErrorReason: entry.ErrorReason);
+    }
+}

--- a/src/Strg.GraphQl/Mutations/Admin/RegenerateThumbnailsMutationHandlers.cs
+++ b/src/Strg.GraphQl/Mutations/Admin/RegenerateThumbnailsMutationHandlers.cs
@@ -1,0 +1,81 @@
+using HotChocolate.Authorization;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Infrastructure.Data;
+
+namespace Strg.GraphQl.Mutations.Admin;
+
+/// <summary>
+/// STRG-342 — admin-triggered backfill mutation. Enumerates <see cref="FileVersion"/> rows
+/// without a <c>Ready</c> or <c>Unsupported</c> thumbnail entry, and publishes one
+/// <see cref="ThumbnailGenerationRequestedEvent"/> per candidate to the outbox.
+///
+/// <para><b>Dedicated event, not republished <see cref="FileUploadedEvent"/>.</b> Republishing
+/// the upload event would double-write audit rows via <c>AuditLogConsumer</c>. The dedicated
+/// event has only the thumbnail consumer subscribing to it.</para>
+///
+/// <para>Returns immediately after staging events — generation is async. The admin UI polls the
+/// affected files (via <c>FileItem.thumbnail</c>) or subscribes to <c>thumbnailReady</c>.</para>
+/// </summary>
+[ExtendObjectType<AdminMutations>]
+public sealed class RegenerateThumbnailsMutationHandlers
+{
+    [Authorize(Policy = "Admin")]
+    public async Task<RegenerateThumbnailsPayload> RegenerateThumbnailsAsync(
+        Guid? driveId,
+        DateTime? olderThan,
+        [Service] StrgDbContext db,
+        [Service] IPublishEndpoint bus,
+        [Service] ITenantContext tenant,
+        CancellationToken cancellationToken)
+    {
+        // Build the candidate query with optional filters. The composite query inherits the
+        // tenant filter on FileItem (TenantedEntity), so cross-tenant driveId values yield
+        // empty result sets — no error needed.
+        var query =
+            from v in db.FileVersions
+            join f in db.Files on v.FileId equals f.Id
+            select new { v.Id, v.FileId, f.DriveId, v.CreatedAt };
+
+        if (driveId is { } d)
+        {
+            query = query.Where(x => x.DriveId == d);
+        }
+
+        if (olderThan is { } cutoff)
+        {
+            query = query.Where(x => x.CreatedAt < cutoff);
+        }
+
+        // Skip rows that already have a Ready or Unsupported entry across ANY variant — those
+        // are settled (Unsupported includes the encrypted-drive carve-out, which we don't want
+        // to retry). Failed rows ARE retried (admin pressed the button explicitly).
+        query = query.Where(x => !db.ThumbnailEntries.Any(t =>
+            t.FileVersionId == x.Id
+            && (t.Status == ThumbnailStatus.Ready || t.Status == ThumbnailStatus.Unsupported)));
+
+        var candidates = await query
+            .Select(x => new { x.FileId, FileVersionId = x.Id, x.DriveId })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        foreach (var candidate in candidates)
+        {
+            await bus.Publish(
+                new ThumbnailGenerationRequestedEvent(
+                    tenant.TenantId,
+                    candidate.FileId,
+                    candidate.FileVersionId,
+                    candidate.DriveId),
+                cancellationToken);
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+
+        return new RegenerateThumbnailsPayload(candidates.Count);
+    }
+}
+
+public sealed record RegenerateThumbnailsPayload(int FilesQueued);

--- a/src/Strg.GraphQl/Subscriptions/ThumbnailSubscriptions.cs
+++ b/src/Strg.GraphQl/Subscriptions/ThumbnailSubscriptions.cs
@@ -1,0 +1,68 @@
+using HotChocolate.Authorization;
+using HotChocolate.Execution;
+using HotChocolate.Subscriptions;
+using Microsoft.AspNetCore.Routing;
+using Strg.Core.Events;
+using Strg.GraphQl.Types;
+
+namespace Strg.GraphQl.Subscriptions;
+
+/// <summary>
+/// Live <c>thumbnailReady(fileId)</c> subscription — fires after
+/// <c>ThumbnailGenerationConsumer</c> commits a Ready row for any of the file's variants.
+///
+/// <para>Authorization mirrors <see cref="FileSubscriptions"/>: the
+/// <see cref="AuthorizeAttribute"/> is the subscribe-time gate; the per-(tenant, file) topic
+/// key (<see cref="Topics.ThumbnailReady"/>) makes cross-tenant subscriptions structurally empty;
+/// the resolver-side guard re-checks tenant on every payload as defence-in-depth.</para>
+/// </summary>
+[ExtendObjectType("Subscription")]
+public sealed class ThumbnailSubscriptions
+{
+    [Subscribe(With = nameof(SubscribeToThumbnailReadyAsync))]
+    [Authorize(Policy = "FilesRead")]
+    public Thumbnail ThumbnailReady(
+        Guid fileId,
+        [EventMessage] ThumbnailReadyEvent evt,
+        [GlobalState("tenantId")] Guid tenantId,
+        [Service] LinkGenerator linkGenerator)
+    {
+        // Defence-in-depth: the topic key is keyed on (tenantId, fileId) so cross-tenant events
+        // should not reach this resolver at all. The guard pins the invariant against any future
+        // regression in the topic-routing layer.
+        if (evt.TenantId != tenantId)
+        {
+            throw new UnauthorizedAccessException("Subscription event tenant mismatch.");
+        }
+        if (evt.FileId != fileId)
+        {
+            throw new UnauthorizedAccessException("Subscription event file mismatch.");
+        }
+
+        // The event payload doesn't carry DriveId for URL building; subscribers re-query the
+        // FileItem.thumbnail GraphQL field for full metadata. Returning a minimal payload keeps
+        // the wire format flat and cheap.
+        var url = linkGenerator.GetPathByName(
+            "GetFileThumbnail",
+            new { fileId = evt.FileId })
+            ?? $"/api/v1/drives/_/files/{evt.FileId}/thumbnail";
+        var fullUrl = $"{url}?variant={Uri.EscapeDataString(evt.Variant)}";
+
+        return new Thumbnail(
+            Url: fullUrl,
+            Width: evt.Width,
+            Height: evt.Height,
+            SizeBytes: null,                // not in event; client can re-fetch via DataLoader
+            Status: ThumbnailStatusGraphQl.Ready,
+            Format: evt.Format,
+            ErrorReason: null);
+    }
+
+    public ValueTask<ISourceStream<ThumbnailReadyEvent>> SubscribeToThumbnailReadyAsync(
+        Guid fileId,
+        [GlobalState("tenantId")] Guid tenantId,
+        [Service] ITopicEventReceiver receiver,
+        CancellationToken cancellationToken) =>
+        receiver.SubscribeAsync<ThumbnailReadyEvent>(
+            Topics.ThumbnailReady(tenantId, fileId), cancellationToken);
+}

--- a/src/Strg.GraphQl/Topics.cs
+++ b/src/Strg.GraphQl/Topics.cs
@@ -38,6 +38,13 @@ public static class Topics
 
     public static string InboxFileProcessed(Guid tenantId) => $"inbox-file-processed:{tenantId}";
 
+    /// <summary>
+    /// Per-(tenant, file) topic for thumbnail-ready notifications. Tenant-prefixed for the same
+    /// reason as <see cref="FileEvents"/> — fileId leaks via shared URLs. Keying on the tuple
+    /// makes a cross-tenant subscriber's channel structurally empty.
+    /// </summary>
+    public static string ThumbnailReady(Guid tenantId, Guid fileId) => $"thumbnail-ready:{tenantId}:{fileId}";
+
     // Per-(tenant, user) topic: only the owner of the quota receives the warning. The tenant
     // prefix prevents a cross-tenant userId collision (theoretical under Guid.NewGuid but pinned
     // at the topic level for defence-in-depth) from leaking a warning to another tenant.

--- a/src/Strg.GraphQl/Types/FileItemType.cs
+++ b/src/Strg.GraphQl/Types/FileItemType.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Strg.Core.Domain;
+using Strg.GraphQl.DataLoaders;
 using Strg.Infrastructure.Data;
 using DomainTag = Strg.Core.Domain.Tag;
 
@@ -20,6 +21,22 @@ public sealed class FileItemType : ObjectType<FileItem>
         descriptor.Field(f => f.TenantId).Ignore();
         descriptor.Field(f => f.StorageKey).Ignore();
         descriptor.Field(f => f.IsDirectory).Ignore();
+
+        // STRG-340 — DataLoader-batched thumbnail field. Returns null when the consumer hasn't
+        // yet produced a row for the (file, variant) pair; clients re-query when the
+        // `thumbnailReady` subscription fires (or just retry after the REST 202's Retry-After).
+        descriptor.Field("thumbnail")
+            .Argument("variant", a => a.Type<NonNullType<EnumType<ThumbnailVariantGraphQl>>>())
+            .Type<ThumbnailType>()
+            .Resolve(async ctx =>
+            {
+                var file = ctx.Parent<FileItem>();
+                var variant = ctx.ArgumentValue<ThumbnailVariantGraphQl>("variant");
+                var loader = ctx.Service<ThumbnailDataLoader>();
+                return await loader.LoadAsync(
+                    new ThumbnailKey(file.Id, variant.ToVariantString()),
+                    ctx.RequestAborted);
+            });
 
         descriptor.Field("children")
             .UsePaging<ObjectType<FileItem>>(options: new() { DefaultPageSize = 50, MaxPageSize = 200 })

--- a/src/Strg.GraphQl/Types/ThumbnailType.cs
+++ b/src/Strg.GraphQl/Types/ThumbnailType.cs
@@ -1,0 +1,70 @@
+using Strg.Core.Domain;
+
+namespace Strg.GraphQl.Types;
+
+/// <summary>
+/// GraphQL projection of <see cref="Strg.Core.Domain.ThumbnailEntry"/>. <see cref="Url"/> always
+/// points to the REST endpoint (single source of truth for byte streaming) — GraphQL is pure
+/// metadata. <see cref="Status"/> mirrors the domain enum 1:1.
+/// </summary>
+public sealed record Thumbnail(
+    string Url,
+    int? Width,
+    int? Height,
+    long? SizeBytes,
+    ThumbnailStatusGraphQl Status,
+    string? Format,
+    string? ErrorReason);
+
+/// <summary>
+/// Wire-level status enum for the GraphQL surface. Numerically aligned with
+/// <see cref="ThumbnailStatus"/> so the cast in <see cref="ThumbnailStatusMap.FromDomain"/> is a
+/// no-op; the explicit conversion centralises a future drift point.
+/// </summary>
+public enum ThumbnailStatusGraphQl
+{
+    Pending = 0,
+    Ready = 1,
+    Failed = 2,
+    Unsupported = 3,
+}
+
+public static class ThumbnailStatusMap
+{
+    public static ThumbnailStatusGraphQl FromDomain(ThumbnailStatus status) =>
+        (ThumbnailStatusGraphQl)status;
+}
+
+/// <summary>
+/// Wire-level variant enum. Hot Chocolate emits this as a GraphQL enum
+/// <c>ThumbnailVariantGraphQl { THUMB, SMALL, MEDIUM }</c>. The string mapping happens at the
+/// resolver edge via <see cref="ToVariantString"/>.
+/// </summary>
+public enum ThumbnailVariantGraphQl
+{
+    Thumb,
+    Small,
+    Medium,
+}
+
+public static class ThumbnailVariantGraphQlExtensions
+{
+    public static string ToVariantString(this ThumbnailVariantGraphQl variant) => variant switch
+    {
+        ThumbnailVariantGraphQl.Thumb => "thumb",
+        ThumbnailVariantGraphQl.Small => "small",
+        ThumbnailVariantGraphQl.Medium => "medium",
+        _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown variant"),
+    };
+}
+
+public sealed class ThumbnailType : ObjectType<Thumbnail>
+{
+    protected override void Configure(IObjectTypeDescriptor<Thumbnail> descriptor)
+    {
+        descriptor.Field(t => t.Url).Type<NonNullType<StringType>>();
+        descriptor.Field(t => t.Status).Type<NonNullType<EnumType<ThumbnailStatusGraphQl>>>();
+        descriptor.Field(t => t.ErrorReason)
+            .Description("Human-readable reason when status is FAILED or UNSUPPORTED. Null otherwise.");
+    }
+}

--- a/src/Strg.Infrastructure/Data/Configurations/ThumbnailEntryConfiguration.cs
+++ b/src/Strg.Infrastructure/Data/Configurations/ThumbnailEntryConfiguration.cs
@@ -1,0 +1,54 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Strg.Core.Domain;
+
+namespace Strg.Infrastructure.Data.Configurations;
+
+public sealed class ThumbnailEntryConfiguration : IEntityTypeConfiguration<ThumbnailEntry>
+{
+    public void Configure(EntityTypeBuilder<ThumbnailEntry> builder)
+    {
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Variant).IsRequired().HasMaxLength(16);
+        builder.Property(t => t.Format).IsRequired().HasMaxLength(16);
+        builder.Property(t => t.StorageKey).IsRequired().HasMaxLength(512);
+        builder.Property(t => t.GeneratorVersion).IsRequired().HasMaxLength(32);
+        builder.Property(t => t.ErrorReason).HasMaxLength(256);
+
+        // string conversion → postgres-readable enum surface; preserves easy migration
+        // semantics (rename a member without a numeric remap) and lines up with the
+        // equivalent decision on FileItem.MimeType (free-text). The trade-off is a few
+        // bytes per row; the upside is grep-ability in pg_dump output during incident
+        // triage.
+        builder.Property(t => t.Status)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(16);
+
+        // Foreign key to FileVersion. Cascade so pruning a FileVersion row removes the
+        // thumbnail rows in the same atomic step (STRG-329 — STRG-332 explicitly relies
+        // on this to keep DB cleanup in the per-version transaction; the consumer is
+        // only responsible for blob cleanup before the row removal).
+        builder.HasOne<FileVersion>()
+            .WithMany()
+            .HasForeignKey(t => t.FileVersionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Idempotency key — the unique index the generation consumer's 23505 catch
+        // discriminates against. Pinned name so a future EF rename surfaces as a
+        // compile break in ThumbnailEntryConstraintNames.
+        builder.HasIndex(t => new { t.FileVersionId, t.Variant, t.Format })
+            .IsUnique()
+            .HasDatabaseName(ThumbnailEntryConstraintNames.UniqueIndex);
+
+        // Backfill enumeration query — `WHERE Status NOT IN (Ready, Unsupported)` is
+        // the candidate-set predicate for `regenerateThumbnails`. Without this index a
+        // backfill over a million-file drive would seq-scan ThumbnailEntries.
+        builder.HasIndex(t => t.Status);
+
+        // FileId index for the cleanup consumer — `WHERE FileId = @id` runs once per
+        // FileDeletedEvent and the table can grow large.
+        builder.HasIndex(t => t.FileId);
+    }
+}

--- a/src/Strg.Infrastructure/Data/Configurations/ThumbnailEntryConstraintNames.cs
+++ b/src/Strg.Infrastructure/Data/Configurations/ThumbnailEntryConstraintNames.cs
@@ -1,0 +1,13 @@
+namespace Strg.Infrastructure.Data.Configurations;
+
+internal static class ThumbnailEntryConstraintNames
+{
+    // Authoritative name of the unique index on (FileVersionId, Variant, Format).
+    // Three consumers need the same string: ThumbnailEntryConfiguration (EF pin via
+    // HasDatabaseName), ThumbnailGenerationConsumer.IsThumbnailUniqueViolation
+    // (equality-match on Npgsql PostgresException.ConstraintName to discriminate
+    // at-least-once redelivery from unrelated unique violations), and MigrationTests
+    // (schema pin). Centralising the literal here turns a silent substring-match
+    // drift into a compile break — same triangulation as AuditEntryConstraintNames.
+    public const string UniqueIndex = "IX_ThumbnailEntries_FileVersionId_Variant_Format";
+}

--- a/src/Strg.Infrastructure/Data/StrgDbContext.cs
+++ b/src/Strg.Infrastructure/Data/StrgDbContext.cs
@@ -36,6 +36,7 @@ public class StrgDbContext(
     public DbSet<FileLock> FileLocks => Set<FileLock>();
     public DbSet<PendingUpload> PendingUploads => Set<PendingUpload>();
     public DbSet<UserDriveDefault> UserDriveDefaults => Set<UserDriveDefault>();
+    public DbSet<ThumbnailEntry> ThumbnailEntries => Set<ThumbnailEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Strg.Infrastructure/Messaging/Consumers/ThumbnailCleanupConsumer.cs
+++ b/src/Strg.Infrastructure/Messaging/Consumers/ThumbnailCleanupConsumer.cs
@@ -1,0 +1,116 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Infrastructure.Data;
+using Strg.Plugin.Abstractions.Storage;
+
+namespace Strg.Infrastructure.Messaging.Consumers;
+
+/// <summary>
+/// STRG-332 — propagates <see cref="FileDeletedEvent"/> to the thumbnail subsystem. Soft-deletes
+/// every <see cref="ThumbnailEntry"/> for the file (across all versions) and best-effort-deletes
+/// the corresponding blobs.
+///
+/// <para><b>Idempotency.</b> Re-delivery finds rows already soft-deleted (excluded by the global
+/// query filter) and reads zero — the consumer no-ops. Best-effort blob delete inherits
+/// <see cref="IStorageProvider.DeleteAsync"/>'s idempotency contract.</para>
+///
+/// <para><b>Why soft-delete and not cascade.</b> The cascade on <see cref="FileVersion"/> handles
+/// row removal when a version row is physically removed (prune). On a regular file delete the
+/// version rows stay (soft-deleted via the file's chain), so we soft-delete thumbnails to mirror.
+/// A blob orphan is preferable to a stuck cleanup loop — blobs get reclaimed by the prune-loop
+/// extension when the version eventually prunes.</para>
+/// </summary>
+public sealed class ThumbnailCleanupConsumer(
+    StrgDbContext db,
+    IStorageProviderRegistry storageRegistry,
+    ILogger<ThumbnailCleanupConsumer> logger) : IConsumer<FileDeletedEvent>
+{
+    public async Task Consume(ConsumeContext<FileDeletedEvent> context)
+    {
+        var msg = context.Message;
+
+        // Consumer scope has empty ITenantContext (MassTransit dispatches outside HTTP). The
+        // global tenant + soft-delete filters on TenantedEntity would otherwise return zero
+        // rows. Bypass + re-apply both predicates inline using the event-carried tenantId.
+        var thumbnails = await db.ThumbnailEntries
+            .IgnoreQueryFilters()
+            .Where(t => t.FileId == msg.FileId
+                        && t.TenantId == msg.TenantId
+                        && !t.DeletedAt.HasValue)
+            .ToListAsync(context.CancellationToken)
+            .ConfigureAwait(false);
+        if (thumbnails.Count == 0)
+        {
+            return;
+        }
+
+        // Resolve provider once — every thumbnail lives on the same drive as its source file.
+        var drive = await db.Drives
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(
+                d => d.Id == msg.DriveId
+                     && d.TenantId == msg.TenantId
+                     && !d.DeletedAt.HasValue,
+                context.CancellationToken)
+            .ConfigureAwait(false);
+        if (drive is not null)
+        {
+            var provider = ResolveProvider(drive);
+
+            foreach (var thumbnail in thumbnails)
+            {
+                if (thumbnail.Status != ThumbnailStatus.Ready
+                    || string.IsNullOrEmpty(thumbnail.StorageKey))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var path = StoragePath.Parse(thumbnail.StorageKey);
+                    await provider.DeleteAsync(path.Value, context.CancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Best-effort. Failure here MUST NOT block the soft-delete; we'd rather have
+                    // an orphan blob than a stuck cleanup. Future prune sweep recovers.
+                    logger.LogWarning(ex,
+                        "ThumbnailCleanupConsumer: best-effort blob delete failed for thumbnail {ThumbnailId}",
+                        thumbnail.Id);
+                }
+            }
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var thumbnail in thumbnails)
+        {
+            thumbnail.DeletedAt = now;
+        }
+        // Re-attach as Modified — the rows were loaded outside the change tracker after
+        // IgnoreQueryFilters() returned them; explicit Update() ensures the timestamp write
+        // reaches the DB.
+        db.ThumbnailEntries.UpdateRange(thumbnails);
+        await db.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+    }
+
+    private IStorageProvider ResolveProvider(Drive drive)
+    {
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        using var json = System.Text.Json.JsonDocument.Parse(drive.ProviderConfig);
+        foreach (var property in json.RootElement.EnumerateObject())
+        {
+            values[property.Name] = property.Value.ValueKind switch
+            {
+                System.Text.Json.JsonValueKind.String => property.Value.GetString(),
+                System.Text.Json.JsonValueKind.Null => null,
+                _ => property.Value.GetRawText(),
+            };
+        }
+        var config = new DictionaryStorageProviderConfig(values);
+        return storageRegistry.Resolve(drive.ProviderType, config);
+    }
+}

--- a/src/Strg.Infrastructure/Messaging/Consumers/ThumbnailGenerationConsumer.cs
+++ b/src/Strg.Infrastructure/Messaging/Consumers/ThumbnailGenerationConsumer.cs
@@ -1,0 +1,119 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Strg.Core.Events;
+using Strg.Core.Services;
+using Strg.Infrastructure.Thumbnails;
+
+namespace Strg.Infrastructure.Messaging.Consumers;
+
+/// <summary>
+/// STRG-331 — generates thumbnails on upload (<see cref="FileUploadedEvent"/>) and on
+/// admin-triggered backfill (<see cref="ThumbnailGenerationRequestedEvent"/>). Both event
+/// types route through the same <see cref="IThumbnailService"/> orchestration so idempotency
+/// + metrics + safeguard logic stay identical.
+///
+/// <para><b>Tenant from payload, not ambient.</b> Same load-bearing rule as
+/// <c>AuditLogConsumer</c> — the consumer's DI scope has an empty <c>ITenantContext</c>.</para>
+///
+/// <para><b>Idempotency.</b> Delegated to <see cref="ThumbnailService"/>'s SQLSTATE-23505 catch
+/// against the pinned <c>IX_ThumbnailEntries_FileVersionId_Variant_Format</c> index.</para>
+///
+/// <para><b>Dead-letter.</b> Sibling <see cref="ThumbnailGenerationFaultObserver"/> logs
+/// <c>{TenantId, FileId, Exceptions}</c> after the 5× retry budget exhausts.</para>
+/// </summary>
+public sealed class ThumbnailGenerationConsumer(
+    IThumbnailService thumbnailService,
+    IOptions<ThumbnailOptions> options,
+    ILogger<ThumbnailGenerationConsumer> logger) :
+    IConsumer<FileUploadedEvent>,
+    IConsumer<ThumbnailGenerationRequestedEvent>
+{
+    public Task Consume(ConsumeContext<FileUploadedEvent> context)
+    {
+        var msg = context.Message;
+        return ProcessAsync(
+            msg.TenantId, msg.FileId, fileVersionId: Guid.Empty, msg.DriveId,
+            context.CancellationToken);
+    }
+
+    public Task Consume(ConsumeContext<ThumbnailGenerationRequestedEvent> context)
+    {
+        var msg = context.Message;
+        return ProcessAsync(
+            msg.TenantId, msg.FileId, msg.FileVersionId, msg.DriveId,
+            context.CancellationToken);
+    }
+
+    private async Task ProcessAsync(
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        Guid driveId,
+        CancellationToken cancellationToken)
+    {
+        var optionsValue = options.Value;
+
+        // FileUploadedEvent doesn't carry the FileVersionId (the upload event predates this
+        // tranche). Resolve the latest version inside the service when fileVersionId is empty.
+        // Backfill events DO carry it explicitly so the admin mutation can target a specific
+        // version (e.g., for a generator-version regen).
+        if (fileVersionId == Guid.Empty)
+        {
+            // Service handles the resolution by querying the latest version for the file.
+            // We could do it here but keeping the lookup inside the service centralises the
+            // tenant-filter discipline.
+        }
+
+        try
+        {
+            await thumbnailService.GenerateAllAsync(
+                tenantId, fileId, fileVersionId, driveId,
+                optionsValue.Variants, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Re-throw so MassTransit retries. Logging here gives operators visibility before
+            // the eventual dead-letter (which the fault observer also logs).
+            logger.LogWarning(ex,
+                "ThumbnailGenerationConsumer: error processing tenant={TenantId} file={FileId} version={FileVersionId}",
+                tenantId, fileId, fileVersionId);
+            throw;
+        }
+    }
+}
+
+/// <summary>
+/// Dead-letter observer for the thumbnail generation pipeline. Logs only safe scalars —
+/// <c>TenantId</c>, <c>FileId</c>, and the projected <c>{ExceptionType}: {Message}</c> array.
+/// No PII, no MIME sniffing output, no path strings.
+/// </summary>
+public sealed class ThumbnailGenerationFaultObserver(ILogger<ThumbnailGenerationFaultObserver> logger) :
+    IConsumer<Fault<FileUploadedEvent>>,
+    IConsumer<Fault<ThumbnailGenerationRequestedEvent>>
+{
+    public Task Consume(ConsumeContext<Fault<FileUploadedEvent>> context)
+    {
+        logger.LogError(
+            "Dead-letter: thumbnail FileUploadedEvent dispatch failed after retries. Tenant={TenantId} File={FileId} Exceptions={Exceptions}",
+            context.Message.Message.TenantId,
+            context.Message.Message.FileId,
+            ProjectExceptions(context.Message.Exceptions));
+        return Task.CompletedTask;
+    }
+
+    public Task Consume(ConsumeContext<Fault<ThumbnailGenerationRequestedEvent>> context)
+    {
+        logger.LogError(
+            "Dead-letter: ThumbnailGenerationRequestedEvent dispatch failed after retries. Tenant={TenantId} File={FileId} Exceptions={Exceptions}",
+            context.Message.Message.TenantId,
+            context.Message.Message.FileId,
+            ProjectExceptions(context.Message.Exceptions));
+        return Task.CompletedTask;
+    }
+
+    // Same projection discipline as AuditLogConsumer.ProjectExceptions — exclude .Data, .StackTrace,
+    // and .ToString() so FK DETAIL / parameter values never reach the structured-log surface.
+    private static string[] ProjectExceptions(ExceptionInfo[] exceptions) =>
+        exceptions.Select(e => $"{e.ExceptionType}: {e.Message}").ToArray();
+}

--- a/src/Strg.Infrastructure/Observability/StrgMetrics.cs
+++ b/src/Strg.Infrastructure/Observability/StrgMetrics.cs
@@ -35,6 +35,18 @@ public sealed class StrgMetrics : IDisposable
     /// <summary>Tracks currently active WebDAV/WebSocket connections.</summary>
     public UpDownCounter<long> ActiveConnections { get; }
 
+    /// <summary>Counts thumbnail generation outcomes — labelled <c>format</c> / <c>variant</c> / <c>status</c>.</summary>
+    public Counter<long> ThumbnailsGeneratedTotal { get; }
+
+    /// <summary>Counts skipped generations — labelled <c>reason</c> (encrypted-drive, too-large, pixel-cap, unknown-mime, no-generator).</summary>
+    public Counter<long> ThumbnailsSkippedTotal { get; }
+
+    /// <summary>Histogram of generation wall time in seconds, labelled <c>format</c>.</summary>
+    public Histogram<double> ThumbnailsGenerationDurationSeconds { get; }
+
+    /// <summary>Concurrent thumbnail generations in flight (UpDownCounter, no labels).</summary>
+    public UpDownCounter<long> ThumbnailsInflight { get; }
+
     public StrgMetrics()
     {
         _meter = new Meter(MeterName);
@@ -50,7 +62,43 @@ public sealed class StrgMetrics : IDisposable
         ActiveConnections = _meter.CreateUpDownCounter<long>(
             "strg_active_connections",
             description: "Active WebDAV/WebSocket connections");
+
+        ThumbnailsGeneratedTotal = _meter.CreateCounter<long>(
+            "strg_thumbnails_generated_total",
+            unit: null,
+            description: "Thumbnail generation outcomes per format / variant / status");
+        ThumbnailsSkippedTotal = _meter.CreateCounter<long>(
+            "strg_thumbnails_skipped_total",
+            unit: null,
+            description: "Thumbnail generation skipped (encrypted-drive, too-large, pixel-cap, unknown-mime, no-generator)");
+        ThumbnailsGenerationDurationSeconds = _meter.CreateHistogram<double>(
+            "strg_thumbnails_generation_duration_seconds",
+            unit: "s",
+            description: "Thumbnail generation wall time per format");
+        ThumbnailsInflight = _meter.CreateUpDownCounter<long>(
+            "strg_thumbnails_inflight",
+            unit: null,
+            description: "Concurrent thumbnail generations in progress");
     }
+
+    /// <summary>Records one thumbnail generation outcome. <paramref name="status"/> is <c>"ready"</c> or <c>"timed-out"</c>.</summary>
+    public void IncrementThumbnailGenerated(string format, string variant, string status) =>
+        ThumbnailsGeneratedTotal.Add(1,
+            new KeyValuePair<string, object?>("format", format),
+            new KeyValuePair<string, object?>("variant", variant),
+            new KeyValuePair<string, object?>("status", status));
+
+    /// <summary>
+    /// Records one skipped generation. <paramref name="reason"/> MUST be from the bounded set
+    /// <c>encrypted-drive | too-large | pixel-cap | unknown-mime | no-generator</c>.
+    /// </summary>
+    public void IncrementThumbnailSkipped(string reason) =>
+        ThumbnailsSkippedTotal.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>Records the wall time of one generation, labelled by output format.</summary>
+    public void RecordThumbnailDuration(string format, double seconds) =>
+        ThumbnailsGenerationDurationSeconds.Record(seconds,
+            new KeyValuePair<string, object?>("format", format));
 
     /// <summary>Records one successful upload and the bytes transferred.</summary>
     public void IncrementUploads(long bytes)

--- a/src/Strg.Infrastructure/Strg.Infrastructure.csproj
+++ b/src/Strg.Infrastructure/Strg.Infrastructure.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="MassTransit.EntityFrameworkCore" />
     <PackageReference Include="MassTransit.RabbitMQ" />
     <PackageReference Include="tusdotnet" />
+    <PackageReference Include="Magick.NET-Q8-x64" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/Strg.Infrastructure/Thumbnails/Generators/MagickNetImageThumbnailer.cs
+++ b/src/Strg.Infrastructure/Thumbnails/Generators/MagickNetImageThumbnailer.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using ImageMagick;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Strg.Core.Services;
+using Strg.Infrastructure.Observability;
+
+namespace Strg.Infrastructure.Thumbnails.Generators;
+
+/// <summary>
+/// Magick.NET-backed image thumbnailer (STRG-336/337/338). Handles JPEG/PNG/WebP/GIF/BMP/TIFF
+/// + HEIC/HEIF (libheif system dep), outputs WebP at the configured quality, letterboxes to a
+/// square white canvas. Pixel-cap probe via <see cref="MagickImageInfo"/> BEFORE full decode.
+/// EXIF auto-orient + metadata strip applied to the output.
+///
+/// <para><b>Resource safeguards (D14).</b> Three layered checks:
+/// <list type="number">
+///   <item>Source-size cap — checked in the consumer BEFORE this generator runs.</item>
+///   <item>Pixel-area cap — header-only probe via <see cref="MagickImageInfo"/>; rejects bombs without decoding the body.</item>
+///   <item>Per-call timeout — linked <see cref="CancellationTokenSource"/> with the operator-tunable budget.</item>
+/// </list>
+/// </para>
+///
+/// <para><b>Privacy (STRG-337).</b> <c>Strip()</c> runs unconditionally before <c>Write()</c> so
+/// the output WebP carries no EXIF/XMP/IPTC/ICC. AI auto-tagging (future) reads the unmodified
+/// source on a separate consumer path; this generator does not affect that.</para>
+/// </summary>
+public sealed class MagickNetImageThumbnailer(
+    IOptions<ThumbnailOptions> options,
+    StrgMetrics metrics,
+    ILogger<MagickNetImageThumbnailer> logger) : IThumbnailGenerator
+{
+    private const string GeneratorVersion = "magick-net-q8/v1";
+
+    // Closed whitelist. CanHandle returns false for anything else so the registry's
+    // first-match-wins routing degrades to "no generator → write Unsupported{no-generator}".
+    private static readonly HashSet<string> SupportedMimes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/gif",
+        "image/bmp",
+        "image/tiff",
+        "image/heic",
+        "image/heif",
+    };
+
+    public string Version => GeneratorVersion;
+
+    public bool CanHandle(string mimeType, ReadOnlySpan<byte> magicBytes) =>
+        !string.IsNullOrEmpty(mimeType) && SupportedMimes.Contains(mimeType);
+
+    public async Task<ThumbnailGenerationOutcome> GenerateAsync(
+        Stream source,
+        ThumbnailRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var optionsValue = options.Value;
+        metrics.ThumbnailsInflight.Add(1);
+        var sw = Stopwatch.StartNew();
+
+        using var timeoutCts = new CancellationTokenSource(
+            TimeSpan.FromSeconds(optionsValue.GenerationTimeoutSeconds));
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            // Read the entire source into a MemoryStream. Magick.NET's MagickImageInfo + MagickImage
+            // both need seekable access — the libraries' streaming variants are unreliable across
+            // formats (HEIC in particular requires a fully buffered input on libheif's side). The
+            // SourceSizeBytes cap (STRG-338) bounds memory at MaxSourceSizeBytes (default 256 MiB),
+            // which the consumer enforces BEFORE invoking this generator.
+            await using var bufferedSource = new MemoryStream(
+                capacity: (int)Math.Min(request.SourceSizeBytes, int.MaxValue));
+            await source.CopyToAsync(bufferedSource, linkedCts.Token).ConfigureAwait(false);
+            bufferedSource.Position = 0;
+
+            // Pixel-cap probe BEFORE full decode (D14). MagickImageInfo reads only the header.
+            MagickImageInfo info;
+            try
+            {
+                info = new MagickImageInfo(bufferedSource);
+            }
+            catch (MagickException ex)
+            {
+                logger.LogDebug("Header-parse failure: {Type}", ex.GetType().Name);
+                return new ThumbnailGenerationOutcome.SourceCorrupt($"header-parse: {ex.GetType().Name}");
+            }
+
+            var pixelArea = (long)info.Width * info.Height;
+            if (pixelArea > optionsValue.MaxPixelArea)
+            {
+                return new ThumbnailGenerationOutcome.ResourceLimitExceeded(
+                    $"pixel-cap ({pixelArea} > {optionsValue.MaxPixelArea})");
+            }
+
+            bufferedSource.Position = 0;
+
+            // Heavy decode + resize on the thread pool so the consumer's await chain stays cheap.
+            // The linked CT propagates both caller cancellation AND the per-call timeout into the
+            // synchronous Magick.NET work via Task.Run + the cancellationToken parameter.
+            return await Task.Run(() => RunMagick(bufferedSource, request, optionsValue, linkedCts.Token), linkedCts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+            when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            // Timeout fired (not caller-initiated cancellation). Distinguishing matters: a caller
+            // cancellation should propagate so MassTransit re-queues; a timeout becomes a Failed
+            // row + "timed-out" metric.
+            return new ThumbnailGenerationOutcome.TimedOut(
+                TimeSpan.FromSeconds(optionsValue.GenerationTimeoutSeconds));
+        }
+        finally
+        {
+            metrics.ThumbnailsInflight.Add(-1);
+            metrics.RecordThumbnailDuration("webp", sw.Elapsed.TotalSeconds);
+        }
+    }
+
+    private static ThumbnailGenerationOutcome RunMagick(
+        Stream input,
+        ThumbnailRequest request,
+        ThumbnailOptions optionsValue,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        using var image = new MagickImage();
+        try
+        {
+            image.Read(input);
+        }
+        catch (MagickException ex)
+        {
+            return new ThumbnailGenerationOutcome.SourceCorrupt($"decode: {ex.GetType().Name}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // 1. AutoOrient FIRST (STRG-337) — applies the EXIF Orientation tag and resets it to 1.
+        //    Doing this BEFORE Resize ensures the resized pixels are upright.
+        image.AutoOrient();
+
+        // 2. Resize the longest edge to the target size; Greater = shrink-only (never enlarge).
+        var edge = (uint)request.TargetEdgePixels;
+        image.Resize(new MagickGeometry(edge, edge)
+        {
+            Greater = true,
+            IgnoreAspectRatio = false,
+        });
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // 3. Letterbox onto a square white canvas (D10).
+        image.BackgroundColor = MagickColors.White;
+        image.Extent(
+            new MagickGeometry(edge, edge),
+            Gravity.Center,
+            MagickColors.White);
+
+        // Flatten any remaining transparency layers onto the white background. PNG inputs with
+        // alpha would otherwise emit a transparent WebP, which defeats the letterbox-on-white
+        // contract.
+        image.Alpha(AlphaOption.Remove);
+
+        // 4. Strip metadata (STRG-337) — privacy: GPS, camera serial, timestamps.
+        image.Strip();
+
+        // 5. Output as WebP at the configured quality.
+        image.Format = MagickFormat.WebP;
+        image.Quality = (uint)optionsValue.WebPQuality;
+
+        var output = new MemoryStream();
+        try
+        {
+            image.Write(output);
+        }
+        catch (MagickException ex)
+        {
+            output.Dispose();
+            return new ThumbnailGenerationOutcome.SourceCorrupt($"encode: {ex.GetType().Name}");
+        }
+
+        output.Position = 0;
+
+        return new ThumbnailGenerationOutcome.Success(
+            output, (int)image.Width, (int)image.Height, "webp");
+    }
+}

--- a/src/Strg.Infrastructure/Thumbnails/ThumbnailGeneratorRegistry.cs
+++ b/src/Strg.Infrastructure/Thumbnails/ThumbnailGeneratorRegistry.cs
@@ -1,0 +1,36 @@
+using Strg.Core.Services;
+
+namespace Strg.Infrastructure.Thumbnails;
+
+/// <summary>
+/// First-registered-wins resolver. The DI container injects every <see cref="IThumbnailGenerator"/>
+/// registration in registration order; the registry walks them and returns the first whose
+/// <see cref="IThumbnailGenerator.CanHandle"/> matches.
+///
+/// <para>Mirrors <c>StorageProviderRegistry</c>'s shape — same first-match-wins discipline so
+/// future test-only generators registered LATER don't accidentally shadow production ones.</para>
+/// </summary>
+public sealed class ThumbnailGeneratorRegistry : IThumbnailGeneratorRegistry
+{
+    private readonly IReadOnlyList<IThumbnailGenerator> _generators;
+
+    public ThumbnailGeneratorRegistry(IEnumerable<IThumbnailGenerator> generators)
+    {
+        ArgumentNullException.ThrowIfNull(generators);
+        _generators = generators.ToArray();
+    }
+
+    public IThumbnailGenerator? Resolve(string mimeType, ReadOnlySpan<byte> magicBytes)
+    {
+        // Manual loop because IEnumerable<>.FirstOrDefault doesn't accept a ref-struct (Span<>)
+        // closure. Bounded N (1–3 generators in v1, ≤5 even with Phase 16 + future plugins).
+        foreach (var generator in _generators)
+        {
+            if (generator.CanHandle(mimeType, magicBytes))
+            {
+                return generator;
+            }
+        }
+        return null;
+    }
+}

--- a/src/Strg.Infrastructure/Thumbnails/ThumbnailOptions.cs
+++ b/src/Strg.Infrastructure/Thumbnails/ThumbnailOptions.cs
@@ -1,0 +1,42 @@
+using System.Collections.ObjectModel;
+
+namespace Strg.Infrastructure.Thumbnails;
+
+/// <summary>
+/// Strongly-typed configuration for the thumbnail subsystem. Bound to the <c>Thumbnails</c>
+/// section in <c>appsettings.json</c>; validated at startup via <see cref="ThumbnailOptionsValidator"/>.
+///
+/// <para><b>Why <c>PdfEnabled</c> / <c>OfficeEnabled</c> exist in v1.</b> Issue #52 mandates the
+/// config gates ship from day 1 even though Phase 16 ships the actual generators. Adding them
+/// later would force a config-schema migration on operators (every appsettings.json across the
+/// fleet would need to grow new keys). Reading the gates is a no-op in v1 — the registry just
+/// has no PDF generator.</para>
+/// </summary>
+public sealed class ThumbnailOptions
+{
+    public const string SectionName = "Thumbnails";
+
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>Variant whitelist; defaults to all three. Each entry must be in <c>ThumbnailVariants.All</c>.</summary>
+    public IReadOnlyList<string> Variants { get; init; } =
+        new ReadOnlyCollection<string>(["thumb", "small", "medium"]);
+
+    /// <summary>Reject sources larger than this without reading. Default 256 MiB.</summary>
+    public long MaxSourceSizeBytes { get; init; } = 256L * 1024 * 1024;
+
+    /// <summary>Reject sources whose decoded pixel area exceeds this without full decode. Default 100 MP.</summary>
+    public long MaxPixelArea { get; init; } = 100_000_000;
+
+    /// <summary>Per-call generation timeout. Default 30 s. Validator caps at 600 s.</summary>
+    public int GenerationTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>WebP quality (1–100). Default 82.</summary>
+    public int WebPQuality { get; init; } = 82;
+
+    /// <summary>Phase 16 gate — no effect in v1 (no PDF generator registered).</summary>
+    public bool PdfEnabled { get; init; } = true;
+
+    /// <summary>Phase 16 gate — no effect in v1 (no Office generator registered).</summary>
+    public bool OfficeEnabled { get; init; }
+}

--- a/src/Strg.Infrastructure/Thumbnails/ThumbnailOptionsValidator.cs
+++ b/src/Strg.Infrastructure/Thumbnails/ThumbnailOptionsValidator.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Options;
+using Strg.Core.Services;
+
+namespace Strg.Infrastructure.Thumbnails;
+
+/// <summary>
+/// Fail-fast validator for <see cref="ThumbnailOptions"/>. Wired via
+/// <c>services.AddOptions&lt;ThumbnailOptions&gt;().ValidateOnStart()</c> so misconfiguration
+/// crashes the host at boot rather than at first thumbnail generation.
+/// </summary>
+internal sealed class ThumbnailOptionsValidator : IValidateOptions<ThumbnailOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ThumbnailOptions options)
+    {
+        var failures = new List<string>();
+
+        if (options.Variants is null || options.Variants.Count == 0)
+        {
+            failures.Add("Thumbnails:Variants must be non-empty.");
+        }
+        else
+        {
+            foreach (var variant in options.Variants)
+            {
+                if (!ThumbnailVariants.IsKnown(variant))
+                {
+                    failures.Add($"Thumbnails:Variants contains unknown variant '{variant}'. Allowed: thumb, small, medium.");
+                }
+            }
+        }
+
+        if (options.MaxSourceSizeBytes <= 0)
+        {
+            failures.Add($"Thumbnails:MaxSourceSizeBytes must be > 0 (got {options.MaxSourceSizeBytes}).");
+        }
+        if (options.MaxPixelArea <= 0)
+        {
+            failures.Add($"Thumbnails:MaxPixelArea must be > 0 (got {options.MaxPixelArea}).");
+        }
+        if (options.GenerationTimeoutSeconds <= 0 || options.GenerationTimeoutSeconds > 600)
+        {
+            failures.Add($"Thumbnails:GenerationTimeoutSeconds must be in (0, 600] (got {options.GenerationTimeoutSeconds}).");
+        }
+        if (options.WebPQuality < 1 || options.WebPQuality > 100)
+        {
+            failures.Add($"Thumbnails:WebPQuality must be in [1, 100] (got {options.WebPQuality}).");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Strg.Infrastructure/Thumbnails/ThumbnailRepository.cs
+++ b/src/Strg.Infrastructure/Thumbnails/ThumbnailRepository.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Strg.Core.Domain;
+using Strg.Infrastructure.Data;
+
+namespace Strg.Infrastructure.Thumbnails;
+
+/// <summary>
+/// EF Core-backed <see cref="IThumbnailRepository"/>. Per project convention, NO calls to
+/// <c>SaveChangesAsync</c> — the consumer / endpoint handler owns the transaction boundary.
+/// </summary>
+public sealed class ThumbnailRepository(StrgDbContext db) : IThumbnailRepository
+{
+    public void Add(ThumbnailEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        db.ThumbnailEntries.Add(entry);
+    }
+
+    public Task<ThumbnailEntry?> GetAsync(
+        Guid fileVersionId,
+        string variant,
+        string format,
+        CancellationToken cancellationToken = default) =>
+        db.ThumbnailEntries.FirstOrDefaultAsync(
+            t => t.FileVersionId == fileVersionId
+                 && t.Variant == variant
+                 && t.Format == format,
+            cancellationToken);
+
+    public async Task<IReadOnlyList<ThumbnailEntry>> GetByFileVersionAsync(
+        Guid fileVersionId,
+        CancellationToken cancellationToken = default) =>
+        await db.ThumbnailEntries
+            .Where(t => t.FileVersionId == fileVersionId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<IReadOnlyList<ThumbnailEntry>> GetByFileAsync(
+        Guid fileId,
+        CancellationToken cancellationToken = default) =>
+        await db.ThumbnailEntries
+            .Where(t => t.FileId == fileId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    public void SoftDeleteRange(IEnumerable<ThumbnailEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        var now = DateTimeOffset.UtcNow;
+        foreach (var entry in entries)
+        {
+            entry.DeletedAt = now;
+        }
+    }
+}

--- a/src/Strg.Infrastructure/Thumbnails/ThumbnailService.cs
+++ b/src/Strg.Infrastructure/Thumbnails/ThumbnailService.cs
@@ -1,0 +1,432 @@
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Npgsql;
+using Strg.Core.Domain;
+using Strg.Core.Events;
+using Strg.Core.Services;
+using Strg.Infrastructure.Data;
+using Strg.Infrastructure.Data.Configurations;
+using Strg.Infrastructure.Observability;
+using Strg.Plugin.Abstractions.Storage;
+
+namespace Strg.Infrastructure.Thumbnails;
+
+/// <summary>
+/// Orchestration layer for the thumbnail subsystem (STRG-330/331). Two callers:
+/// <list type="bullet">
+///   <item><c>ThumbnailGenerationConsumer</c> on <c>FileUploadedEvent</c> (upload path).</item>
+///   <item><c>ThumbnailGenerationConsumer</c> on <c>ThumbnailGenerationRequestedEvent</c> (admin backfill).</item>
+/// </list>
+/// Both share <see cref="GenerateAllAsync"/> so the upload and backfill paths exercise the
+/// same idempotency / metrics / safeguard logic.
+///
+/// <para><b>Encrypted-drive carve-out (D17).</b> When <c>Drive.EncryptionEnabled</c> is true,
+/// writes a single <see cref="ThumbnailStatus.Unsupported"/> row + <c>strg_thumbnails_skipped_total{reason=encrypted-drive}</c>
+/// metric and exits. Decryption-aware reads land in a future phase (planned STRG-347).</para>
+///
+/// <para><b>Idempotency.</b> SQLSTATE 23505 + exact <c>ConstraintName</c> equality discriminates
+/// at-least-once redelivery from unrelated unique violations — same triangulation as
+/// <c>AuditLogConsumer.IsEventIdUniqueViolation</c>.</para>
+/// </summary>
+public sealed class ThumbnailService(
+    StrgDbContext db,
+    IThumbnailRepository repo,
+    IThumbnailGeneratorRegistry registry,
+    IStorageProviderRegistry storageRegistry,
+    IPublishEndpoint bus,
+    IOptions<ThumbnailOptions> options,
+    StrgMetrics metrics,
+    TimeProvider clock,
+    ILogger<ThumbnailService> logger) : IThumbnailService
+{
+    private const string UniqueViolationSqlState = "23505";
+    private const int MagicByteWindow = 64;
+
+    public async Task GenerateAllAsync(
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        Guid driveId,
+        IReadOnlyList<string> variants,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(variants);
+
+        var optionsValue = options.Value;
+        if (!optionsValue.Enabled)
+        {
+            logger.LogDebug("Thumbnails disabled by config; skipping FileId={FileId}", fileId);
+            return;
+        }
+
+        // Consumer scope has empty ITenantContext (MassTransit dispatches outside any HTTP
+        // request — same load-bearing rule as AuditLogConsumer). The global tenant + soft-delete
+        // filters on TenantedEntity therefore evaluate to "TenantId == Guid.Empty AND DeletedAt
+        // IS NULL", which excludes every legitimate row. We bypass via IgnoreQueryFilters and
+        // re-apply BOTH predicates inline using the event-carried tenantId — the same carve-out
+        // pattern as UserRepository.GetByEmailAsync (pre-auth lookup) and DriveRepository's
+        // tenant-aware reads.
+        var file = await db.Files
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                f => f.Id == fileId && f.TenantId == tenantId && !f.DeletedAt.HasValue,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (file is null)
+        {
+            logger.LogDebug("File {FileId} not visible (deleted/cross-tenant); skipping thumbnails", fileId);
+            return;
+        }
+
+        // FileVersion is Entity (not TenantedEntity) — no global filter applies. Tenant
+        // isolation is transitive via FileVersion.FileId → FileItem.TenantId, already enforced
+        // by the FileItem read above. If fileVersionId is Guid.Empty (FileUploadedEvent path),
+        // pick the latest version of the file.
+        var version = fileVersionId == Guid.Empty
+            ? await db.FileVersions
+                .AsNoTracking()
+                .Where(v => v.FileId == fileId)
+                .OrderByDescending(v => v.VersionNumber)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false)
+            : await db.FileVersions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(v => v.Id == fileVersionId && v.FileId == fileId, cancellationToken)
+                .ConfigureAwait(false);
+        if (version is null)
+        {
+            logger.LogDebug("FileVersion {FileVersionId} not found; skipping thumbnails", fileVersionId);
+            return;
+        }
+
+        var drive = await db.Drives
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                d => d.Id == driveId && d.TenantId == tenantId && !d.DeletedAt.HasValue,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (drive is null)
+        {
+            logger.LogDebug("Drive {DriveId} not visible; skipping thumbnails", driveId);
+            return;
+        }
+
+        // Encrypted-drive carve-out (D17). One row only, deterministic variant/format so
+        // re-delivery hits the unique-index idempotency path.
+        if (drive.EncryptionEnabled)
+        {
+            await TryAddCarveOutRowAsync(
+                tenantId, fileId, version.Id,
+                variant: ThumbnailVariants.Thumb,
+                reason: "encrypted-drive-not-yet-supported",
+                cancellationToken).ConfigureAwait(false);
+            metrics.IncrementThumbnailSkipped("encrypted-drive");
+            return;
+        }
+
+        // Source-size cap (STRG-338) — rejects before any blob I/O.
+        if (version.Size > optionsValue.MaxSourceSizeBytes)
+        {
+            foreach (var variant in variants)
+            {
+                await TryAddCarveOutRowAsync(
+                    tenantId, fileId, version.Id, variant,
+                    reason: "too-large", cancellationToken).ConfigureAwait(false);
+            }
+            metrics.IncrementThumbnailSkipped("too-large");
+            return;
+        }
+
+        var provider = ResolveProvider(drive);
+
+        // Sniff the source MIME from the first ~64 bytes (D12). FileItem.MimeType is
+        // client-provided and untrusted; we trust the bytes.
+        var headBuffer = new byte[MagicByteWindow];
+        int read;
+        await using (var headStream = await provider.ReadAsync(version.StorageKey, 0, cancellationToken).ConfigureAwait(false))
+        {
+            read = await ReadFullyAsync(headStream, headBuffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        var sniffedMime = MimeSniffer.Detect(headBuffer.AsSpan(0, read));
+        if (sniffedMime is null)
+        {
+            foreach (var variant in variants)
+            {
+                await TryAddCarveOutRowAsync(
+                    tenantId, fileId, version.Id, variant,
+                    reason: "unknown-mime", cancellationToken).ConfigureAwait(false);
+            }
+            metrics.IncrementThumbnailSkipped("unknown-mime");
+            return;
+        }
+
+        var generator = registry.Resolve(sniffedMime, headBuffer.AsSpan(0, read));
+        if (generator is null)
+        {
+            foreach (var variant in variants)
+            {
+                await TryAddCarveOutRowAsync(
+                    tenantId, fileId, version.Id, variant,
+                    reason: "no-generator", cancellationToken).ConfigureAwait(false);
+            }
+            metrics.IncrementThumbnailSkipped("no-generator");
+            return;
+        }
+
+        // Per-variant fan-out. Each variant is its own atomic step (insert Pending → generate →
+        // write blob → update Ready). Failure on variant N does not roll back N-1.
+        foreach (var variant in variants)
+        {
+            await GenerateOneAsync(
+                tenantId, fileId, version.Id, driveId, variant, generator,
+                provider, version.StorageKey, version.Size, sniffedMime,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task GenerateOneAsync(
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        Guid driveId,
+        string variant,
+        IThumbnailGenerator generator,
+        IStorageProvider provider,
+        string sourceStorageKey,
+        long sourceSize,
+        string sourceMime,
+        CancellationToken cancellationToken)
+    {
+        const string format = ThumbnailFormats.WebP;
+
+        // Idempotency probe. A re-delivery may find a Ready/Unsupported/Failed row from a
+        // prior attempt — short-circuit without re-running the generator. The unique-index
+        // catch below remains as the race-safe defence.
+        var existing = await repo.GetAsync(fileVersionId, variant, format, cancellationToken)
+            .ConfigureAwait(false);
+        if (existing is not null && existing.Status != ThumbnailStatus.Pending)
+        {
+            return;
+        }
+
+        // Insert (or update) the Pending row. Any 23505 means a concurrent worker landed the
+        // row first; we no-op and let them finish.
+        ThumbnailEntry pendingRow;
+        if (existing is null)
+        {
+            pendingRow = new ThumbnailEntry
+            {
+                TenantId = tenantId,
+                FileId = fileId,
+                FileVersionId = fileVersionId,
+                Variant = variant,
+                Format = format,
+                Status = ThumbnailStatus.Pending,
+                GeneratorVersion = generator.Version,
+            };
+            repo.Add(pendingRow);
+
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateException ex) when (IsThumbnailUniqueViolation(ex))
+            {
+                db.ChangeTracker.Clear();
+                logger.LogDebug(
+                    "ThumbnailService: concurrent worker landed {Variant}/{Format} for {FileVersionId}; no-op",
+                    variant, format, fileVersionId);
+                return;
+            }
+        }
+        else
+        {
+            pendingRow = existing;
+        }
+
+        ThumbnailGenerationOutcome outcome;
+        try
+        {
+            await using var sourceStream = await provider
+                .ReadAsync(sourceStorageKey, 0, cancellationToken)
+                .ConfigureAwait(false);
+
+            outcome = await generator.GenerateAsync(
+                sourceStream,
+                new ThumbnailRequest(
+                    Variant: variant,
+                    TargetEdgePixels: ThumbnailVariants.EdgePixelsFor(variant),
+                    TargetFormat: format,
+                    SourceSizeBytes: sourceSize,
+                    SourceMimeType: sourceMime),
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Caller cancellation — let MassTransit re-queue. Pending row stays.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "ThumbnailService: generator threw for {FileVersionId}/{Variant}; marking Failed",
+                fileVersionId, variant);
+            pendingRow.Status = ThumbnailStatus.Failed;
+            pendingRow.ErrorReason = $"generator-error: {ex.GetType().Name}";
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            metrics.IncrementThumbnailGenerated(format, variant, "error");
+            return;
+        }
+
+        switch (outcome)
+        {
+            case ThumbnailGenerationOutcome.Success success:
+                await PromoteToReadyAsync(
+                    pendingRow, success, tenantId, fileId, fileVersionId, driveId, variant, format,
+                    provider, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case ThumbnailGenerationOutcome.Unsupported u:
+                pendingRow.Status = ThumbnailStatus.Unsupported;
+                pendingRow.ErrorReason = u.Reason;
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                metrics.IncrementThumbnailSkipped("unknown-mime");
+                break;
+
+            case ThumbnailGenerationOutcome.SourceCorrupt corrupt:
+                pendingRow.Status = ThumbnailStatus.Failed;
+                pendingRow.ErrorReason = corrupt.Reason;
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                metrics.IncrementThumbnailGenerated(format, variant, "source-corrupt");
+                break;
+
+            case ThumbnailGenerationOutcome.ResourceLimitExceeded rle:
+                pendingRow.Status = ThumbnailStatus.Unsupported;
+                pendingRow.ErrorReason = rle.Reason;
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                metrics.IncrementThumbnailSkipped("pixel-cap");
+                break;
+
+            case ThumbnailGenerationOutcome.TimedOut t:
+                pendingRow.Status = ThumbnailStatus.Failed;
+                pendingRow.ErrorReason = $"timeout ({t.Limit.TotalSeconds:F0}s)";
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                metrics.IncrementThumbnailGenerated(format, variant, "timed-out");
+                break;
+        }
+    }
+
+    private async Task PromoteToReadyAsync(
+        ThumbnailEntry row,
+        ThumbnailGenerationOutcome.Success success,
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        Guid driveId,
+        string variant,
+        string format,
+        IStorageProvider provider,
+        CancellationToken cancellationToken)
+    {
+        await using var output = success.Output;
+
+        var key = ThumbnailStorageKeyBuilder.Build(driveId, fileVersionId, variant, format);
+        var path = StoragePath.Parse(key);
+
+        await provider.WriteAsync(path.Value, output, cancellationToken).ConfigureAwait(false);
+
+        row.Status = ThumbnailStatus.Ready;
+        row.StorageKey = path.Value;
+        row.Width = success.Width;
+        row.Height = success.Height;
+        row.SizeBytes = output.Length;
+        row.GeneratedAt = clock.GetUtcNow();
+        row.ErrorReason = null;
+
+        // Outbox publish BEFORE SaveChanges — the event and the row update commit atomically
+        // through MassTransit's EF outbox.
+        await bus.Publish(
+            new ThumbnailReadyEvent(tenantId, fileId, fileVersionId, variant, format, success.Width, success.Height),
+            cancellationToken).ConfigureAwait(false);
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        metrics.IncrementThumbnailGenerated(format, variant, "ready");
+    }
+
+    private async Task TryAddCarveOutRowAsync(
+        Guid tenantId,
+        Guid fileId,
+        Guid fileVersionId,
+        string variant,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var row = new ThumbnailEntry
+        {
+            TenantId = tenantId,
+            FileId = fileId,
+            FileVersionId = fileVersionId,
+            Variant = variant,
+            Format = ThumbnailFormats.WebP,
+            Status = ThumbnailStatus.Unsupported,
+            ErrorReason = reason,
+            GeneratorVersion = "carve-out/v1",
+        };
+        repo.Add(row);
+
+        try
+        {
+            await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsThumbnailUniqueViolation(ex))
+        {
+            db.ChangeTracker.Clear();
+        }
+    }
+
+    private static async Task<int> ReadFullyAsync(Stream source, byte[] buffer, CancellationToken cancellationToken)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var read = await source.ReadAsync(buffer.AsMemory(total), cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+            total += read;
+        }
+        return total;
+    }
+
+    private IStorageProvider ResolveProvider(Drive drive)
+    {
+        // Mirror FileVersionStore.ResolveProvider — same JSON-config contract.
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        using var json = System.Text.Json.JsonDocument.Parse(drive.ProviderConfig);
+        foreach (var property in json.RootElement.EnumerateObject())
+        {
+            values[property.Name] = property.Value.ValueKind switch
+            {
+                System.Text.Json.JsonValueKind.String => property.Value.GetString(),
+                System.Text.Json.JsonValueKind.Null => null,
+                _ => property.Value.GetRawText(),
+            };
+        }
+        var config = new DictionaryStorageProviderConfig(values);
+        return storageRegistry.Resolve(drive.ProviderType, config);
+    }
+
+    // internal so unit tests in Strg.Api.Tests can verify the discrimination invariant without
+    // booting Postgres — same precedent as AuditLogConsumer.IsEventIdUniqueViolation.
+    internal static bool IsThumbnailUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg
+        && pg.SqlState == UniqueViolationSqlState
+        && pg.ConstraintName == ThumbnailEntryConstraintNames.UniqueIndex;
+}

--- a/src/Strg.Infrastructure/Versioning/FileVersionStore.cs
+++ b/src/Strg.Infrastructure/Versioning/FileVersionStore.cs
@@ -161,6 +161,42 @@ public sealed class FileVersionStore(
         {
             await provider.DeleteAsync(version.StorageKey, cancellationToken).ConfigureAwait(false);
 
+            // STRG-332: best-effort thumbnail blob delete. The ThumbnailEntry rows themselves
+            // cascade away when db.FileVersions.Remove(version) commits inside the per-version
+            // transaction (OnDelete(Cascade) configured in ThumbnailEntryConfiguration). The
+            // blobs do NOT cascade, so we enumerate them here and call IStorageProvider.DeleteAsync
+            // — load-bearing on the provider's idempotency contract: a missing blob from a prior
+            // partial-prune retry MUST NOT throw and stall the loop at iteration k.
+            //
+            // Stays OUTSIDE the per-version transaction (matches the existing pattern for
+            // version.StorageKey — blob deletion is best-effort even when the DB tx commits).
+            // A failure here logs a warning via the storage provider's own logging path and the
+            // orphan is reclaimable on a future re-prune.
+            var thumbnailKeys = await db.ThumbnailEntries
+                .Where(t => t.FileVersionId == version.Id
+                            && t.Status == Strg.Core.Domain.ThumbnailStatus.Ready)
+                .Select(t => t.StorageKey)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var thumbnailKey in thumbnailKeys)
+            {
+                if (string.IsNullOrEmpty(thumbnailKey))
+                {
+                    continue;
+                }
+                try
+                {
+                    await provider.DeleteAsync(thumbnailKey, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogWarning(ex,
+                        "FileVersionStore: best-effort thumbnail blob delete failed for {Key} (version {VersionId})",
+                        thumbnailKey, version.Id);
+                }
+            }
+
             await using var tx = await db.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
             db.FileVersions.Remove(version);
             await quotaService.ReleaseAsync(file.CreatedBy, version.Size, cancellationToken).ConfigureAwait(false);

--- a/tests/Strg.Api.Tests/Messaging/ThumbnailIdempotencyDiscriminationTests.cs
+++ b/tests/Strg.Api.Tests/Messaging/ThumbnailIdempotencyDiscriminationTests.cs
@@ -1,0 +1,100 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Strg.Infrastructure.Data.Configurations;
+using Strg.Infrastructure.Thumbnails;
+using Xunit;
+
+namespace Strg.Api.Tests.Messaging;
+
+/// <summary>
+/// STRG-331 — pins the negative case of <see cref="ThumbnailService.IsThumbnailUniqueViolation"/>.
+/// Mirror of <see cref="ConsumerIdempotencyDiscriminationTests"/> for the audit consumer:
+/// a future refactor that broadens the predicate (drops the <c>ConstraintName</c> equality, or
+/// relaxes to <c>Contains</c>) would silently swallow unrelated unique violations on future
+/// indexes added to <c>ThumbnailEntries</c> (e.g. a <c>(FileId, GeneratorVersion)</c> dedup
+/// index for a generator-bump regen).
+/// </summary>
+public sealed class ThumbnailIdempotencyDiscriminationTests
+{
+    private const string UniqueViolation = "23505";
+    private const string ForeignKeyViolation = "23503";
+    private const string CheckViolation = "23514";
+
+    [Fact]
+    public void Swallows_23505_on_pinned_unique_index()
+    {
+        var ex = BuildDbUpdateException(UniqueViolation, ThumbnailEntryConstraintNames.UniqueIndex);
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeTrue(
+            "the positive case — real redelivery collision on the (FileVersionId, Variant, Format) " +
+            "index — is the only shape the catch filter is licensed to swallow");
+    }
+
+    [Fact]
+    public void Rethrows_23505_on_different_unique_index()
+    {
+        // Hypothetical second unique index that's NOT the idempotency key.
+        var ex = BuildDbUpdateException(UniqueViolation, "IX_ThumbnailEntries_TenantId_FileId_Variant");
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeFalse(
+            "a 23505 on a different unique index is a real domain-rule violation that must " +
+            "propagate so MassTransit retries / dead-letters; swallowing it would silently drop " +
+            "the failure mode");
+    }
+
+    [Fact]
+    public void Rethrows_23505_on_substring_match_to_constraint_name()
+    {
+        // A future index whose name happens to contain the same substring (e.g.
+        // "IX_ThumbnailEntries_FileVersionId" — different shape, different intent). The exact-
+        // equality contract pinned here means that name does NOT collapse into the idempotency
+        // bucket.
+        var ex = BuildDbUpdateException(UniqueViolation, "IX_ThumbnailEntries_FileVersionId");
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeFalse(
+            "exact equality (not substring match) — a future index whose name shares a prefix " +
+            "with the canonical idempotency index is a different constraint and must NOT be " +
+            "swallowed");
+    }
+
+    [Fact]
+    public void Rethrows_23503_FK_violation_on_target_index_name()
+    {
+        var ex = BuildDbUpdateException(ForeignKeyViolation, ThumbnailEntryConstraintNames.UniqueIndex);
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeFalse(
+            "non-23505 SqlStates (FK violations, check violations) are unrelated failure modes " +
+            "and must propagate even when the constraint name happens to match");
+    }
+
+    [Fact]
+    public void Rethrows_23514_check_violation_on_target_index_name()
+    {
+        var ex = BuildDbUpdateException(CheckViolation, ThumbnailEntryConstraintNames.UniqueIndex);
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Rethrows_when_InnerException_is_not_PostgresException()
+    {
+        var ex = new DbUpdateException(
+            "non-Postgres cause",
+            new TimeoutException("connection pool exhausted"));
+
+        ThumbnailService.IsThumbnailUniqueViolation(ex).Should().BeFalse(
+            "non-PostgresException inner causes (e.g. SQLite layer in dev, transient network) " +
+            "are unrelated to the Npgsql unique-violation contract");
+    }
+
+    private static DbUpdateException BuildDbUpdateException(string sqlState, string? constraintName) =>
+        new(
+            "test-only synthetic DbUpdateException",
+            new PostgresException(
+                messageText: "fabricated unique-violation for predicate test",
+                severity: "ERROR",
+                invariantSeverity: "ERROR",
+                sqlState: sqlState,
+                constraintName: constraintName));
+}

--- a/tests/Strg.Api.Tests/Thumbnails/ThumbnailOptionsValidatorTests.cs
+++ b/tests/Strg.Api.Tests/Thumbnails/ThumbnailOptionsValidatorTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Strg.Infrastructure.Thumbnails;
+using Xunit;
+
+namespace Strg.Api.Tests.Thumbnails;
+
+/// <summary>
+/// STRG-334 — pins fail-fast startup validation for <see cref="ThumbnailOptions"/>. Each rule
+/// has both a positive (default config passes) and a negative (each invalid input rejected
+/// with a named field in the message) coverage.
+/// </summary>
+public sealed class ThumbnailOptionsValidatorTests
+{
+    private static readonly ThumbnailOptionsValidator Validator = new();
+
+    [Fact]
+    public void Defaults_Pass()
+    {
+        var opt = new ThumbnailOptions();
+        var result = Validator.Validate(name: null, opt);
+        result.Succeeded.Should().BeTrue(because: $"failures: {string.Join(", ", result.Failures ?? [])}");
+    }
+
+    [Fact]
+    public void EmptyVariants_Fails()
+    {
+        var opt = new ThumbnailOptions { Variants = Array.Empty<string>() };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("Variants");
+    }
+
+    [Fact]
+    public void UnknownVariant_Fails_AndNamesIt()
+    {
+        var opt = new ThumbnailOptions { Variants = new[] { "small", "huge" } };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("'huge'");
+    }
+
+    [Fact]
+    public void ZeroMaxSourceSize_Fails()
+    {
+        var opt = new ThumbnailOptions { MaxSourceSizeBytes = 0 };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("MaxSourceSizeBytes");
+    }
+
+    [Fact]
+    public void NegativeMaxPixelArea_Fails()
+    {
+        var opt = new ThumbnailOptions { MaxPixelArea = -1 };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("MaxPixelArea");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(601)]
+    [InlineData(99999)]
+    public void TimeoutOutOfRange_Fails(int seconds)
+    {
+        var opt = new ThumbnailOptions { GenerationTimeoutSeconds = seconds };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("GenerationTimeoutSeconds");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(82)]
+    [InlineData(600)]
+    public void TimeoutInRange_Passes(int seconds)
+    {
+        var opt = new ThumbnailOptions { GenerationTimeoutSeconds = seconds };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(101)]
+    public void WebPQualityOutOfRange_Fails(int quality)
+    {
+        var opt = new ThumbnailOptions { WebPQuality = quality };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeFalse();
+        result.FailureMessage.Should().Contain("WebPQuality");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(82)]
+    [InlineData(100)]
+    public void WebPQualityInRange_Passes(int quality)
+    {
+        var opt = new ThumbnailOptions { WebPQuality = quality };
+        var result = Validator.Validate(null, opt);
+        result.Succeeded.Should().BeTrue();
+    }
+}

--- a/tests/Strg.Core.Tests/Domain/ThumbnailEntryTests.cs
+++ b/tests/Strg.Core.Tests/Domain/ThumbnailEntryTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Strg.Core.Domain;
+using Xunit;
+
+namespace Strg.Core.Tests.Domain;
+
+public sealed class ThumbnailEntryTests
+{
+    [Fact]
+    public void Defaults_AreSensible()
+    {
+        var entry = new ThumbnailEntry
+        {
+            FileVersionId = Guid.NewGuid(),
+            FileId = Guid.NewGuid(),
+            Variant = "small",
+            Format = "webp",
+            GeneratorVersion = "magick-net-q8/v1",
+        };
+
+        entry.Status.Should().Be(ThumbnailStatus.Pending);
+        entry.StorageKey.Should().BeEmpty();
+        entry.SizeBytes.Should().Be(0);
+        entry.Width.Should().Be(0);
+        entry.Height.Should().Be(0);
+        entry.GeneratedAt.Should().BeNull();
+        entry.ErrorReason.Should().BeNull();
+        entry.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TenantedEntity_InheritsTenantId()
+    {
+        var tenantId = Guid.NewGuid();
+        var entry = new ThumbnailEntry
+        {
+            TenantId = tenantId,
+            FileVersionId = Guid.NewGuid(),
+            FileId = Guid.NewGuid(),
+            Variant = "thumb",
+            Format = "webp",
+            GeneratorVersion = "magick-net-q8/v1",
+        };
+        entry.TenantId.Should().Be(tenantId);
+    }
+}

--- a/tests/Strg.Core.Tests/Services/MimeSnifferTests.cs
+++ b/tests/Strg.Core.Tests/Services/MimeSnifferTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using Strg.Core.Services;
+using Xunit;
+
+namespace Strg.Core.Tests.Services;
+
+public sealed class MimeSnifferTests
+{
+    [Fact]
+    public void Detect_Jpeg()
+    {
+        ReadOnlySpan<byte> jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46];
+        MimeSniffer.Detect(jpeg).Should().Be("image/jpeg");
+    }
+
+    [Fact]
+    public void Detect_Png()
+    {
+        ReadOnlySpan<byte> png = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00];
+        MimeSniffer.Detect(png).Should().Be("image/png");
+    }
+
+    [Theory]
+    [InlineData(0x37)] // GIF87a
+    [InlineData(0x39)] // GIF89a
+    public void Detect_Gif(byte versionByte)
+    {
+        ReadOnlySpan<byte> gif = [0x47, 0x49, 0x46, 0x38, versionByte, 0x61, 0x00, 0x00];
+        MimeSniffer.Detect(gif).Should().Be("image/gif");
+    }
+
+    [Fact]
+    public void Detect_WebP()
+    {
+        ReadOnlySpan<byte> webp =
+        [
+            0x52, 0x49, 0x46, 0x46, // "RIFF"
+            0x24, 0x00, 0x00, 0x00, // file size (irrelevant)
+            0x57, 0x45, 0x42, 0x50, // "WEBP"
+        ];
+        MimeSniffer.Detect(webp).Should().Be("image/webp");
+    }
+
+    [Fact]
+    public void Detect_Pdf()
+    {
+        ReadOnlySpan<byte> pdf = [0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E, 0x37];
+        MimeSniffer.Detect(pdf).Should().Be("application/pdf");
+    }
+
+    [Fact]
+    public void Detect_HeicBrand()
+    {
+        // bytes 4..7 = "ftyp", brand at 8..11 = "heic"
+        ReadOnlySpan<byte> heic =
+        [
+            0x00, 0x00, 0x00, 0x18,
+            0x66, 0x74, 0x79, 0x70,
+            0x68, 0x65, 0x69, 0x63,
+        ];
+        MimeSniffer.Detect(heic).Should().Be("image/heic");
+    }
+
+    [Fact]
+    public void Detect_MifBrand_AsHeif()
+    {
+        ReadOnlySpan<byte> heif =
+        [
+            0x00, 0x00, 0x00, 0x18,
+            0x66, 0x74, 0x79, 0x70,
+            0x6D, 0x69, 0x66, 0x31,  // "mif1"
+        ];
+        MimeSniffer.Detect(heif).Should().Be("image/heif");
+    }
+
+    [Fact]
+    public void Detect_UnknownFtypBrand_ReturnsNull()
+    {
+        ReadOnlySpan<byte> unknown =
+        [
+            0x00, 0x00, 0x00, 0x18,
+            0x66, 0x74, 0x79, 0x70,
+            0x6D, 0x70, 0x34, 0x32,  // "mp42" — not in the whitelist
+        ];
+        MimeSniffer.Detect(unknown).Should().BeNull();
+    }
+
+    [Fact]
+    public void Detect_TruncatedJpeg_ReturnsNull()
+    {
+        ReadOnlySpan<byte> truncated = [0xFF, 0xD8];   // missing third signature byte
+        MimeSniffer.Detect(truncated).Should().BeNull();
+    }
+
+    [Fact]
+    public void Detect_Empty_ReturnsNull()
+    {
+        MimeSniffer.Detect(ReadOnlySpan<byte>.Empty).Should().BeNull();
+    }
+
+    [Fact]
+    public void Detect_RandomGarbage_ReturnsNull()
+    {
+        ReadOnlySpan<byte> garbage = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B];
+        MimeSniffer.Detect(garbage).Should().BeNull();
+    }
+
+    [Fact]
+    public void Detect_RiffWithoutWebpFourCc_ReturnsNull()
+    {
+        ReadOnlySpan<byte> riffWav =
+        [
+            0x52, 0x49, 0x46, 0x46,
+            0x00, 0x00, 0x00, 0x00,
+            0x57, 0x41, 0x56, 0x45,  // "WAVE" — not WebP
+        ];
+        MimeSniffer.Detect(riffWav).Should().BeNull();
+    }
+}

--- a/tests/Strg.Core.Tests/Services/ThumbnailStorageKeyBuilderTests.cs
+++ b/tests/Strg.Core.Tests/Services/ThumbnailStorageKeyBuilderTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Strg.Core.Services;
+using Xunit;
+
+namespace Strg.Core.Tests.Services;
+
+public sealed class ThumbnailStorageKeyBuilderTests
+{
+    private static readonly Guid DriveId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid VersionId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void Build_Canonical_Format()
+    {
+        var key = ThumbnailStorageKeyBuilder.Build(DriveId, VersionId, ThumbnailVariants.Small, ThumbnailFormats.WebP);
+        key.Should().Be(
+            "thumbnails/11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222/small.webp");
+    }
+
+    [Theory]
+    [InlineData("thumb")]
+    [InlineData("small")]
+    [InlineData("medium")]
+    public void Build_AllVariants_Succeed(string variant)
+    {
+        var act = () => ThumbnailStorageKeyBuilder.Build(DriveId, VersionId, variant, ThumbnailFormats.WebP);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Build_EmptyDriveId_Throws()
+    {
+        var act = () => ThumbnailStorageKeyBuilder.Build(Guid.Empty, VersionId, ThumbnailVariants.Thumb, ThumbnailFormats.WebP);
+        act.Should().Throw<ArgumentException>().WithMessage("*Drive id*");
+    }
+
+    [Fact]
+    public void Build_EmptyVersionId_Throws()
+    {
+        var act = () => ThumbnailStorageKeyBuilder.Build(DriveId, Guid.Empty, ThumbnailVariants.Thumb, ThumbnailFormats.WebP);
+        act.Should().Throw<ArgumentException>().WithMessage("*File version id*");
+    }
+
+    [Fact]
+    public void Build_UnknownVariant_Throws()
+    {
+        var act = () => ThumbnailStorageKeyBuilder.Build(DriveId, VersionId, "huge", ThumbnailFormats.WebP);
+        act.Should().Throw<ArgumentException>().WithMessage("*Unknown thumbnail variant*'huge'*");
+    }
+
+    [Fact]
+    public void Build_UnknownFormat_Throws()
+    {
+        var act = () => ThumbnailStorageKeyBuilder.Build(DriveId, VersionId, ThumbnailVariants.Thumb, "avif");
+        act.Should().Throw<ArgumentException>().WithMessage("*Unknown thumbnail format*'avif'*");
+    }
+}
+
+public sealed class ThumbnailVariantsTests
+{
+    [Theory]
+    [InlineData("thumb", 256)]
+    [InlineData("small", 512)]
+    [InlineData("medium", 1024)]
+    public void EdgePixelsFor_Known(string variant, int expected)
+    {
+        ThumbnailVariants.EdgePixelsFor(variant).Should().Be(expected);
+    }
+
+    [Fact]
+    public void EdgePixelsFor_Unknown_Throws()
+    {
+        var act = () => ThumbnailVariants.EdgePixelsFor("huge");
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData("thumb", true)]
+    [InlineData("small", true)]
+    [InlineData("medium", true)]
+    [InlineData("huge", false)]
+    [InlineData("THUMB", false)] // case-sensitive — DB column is varchar; canonical is lowercase
+    [InlineData("", false)]
+    public void IsKnown_Cases(string variant, bool expected)
+    {
+        ThumbnailVariants.IsKnown(variant).Should().Be(expected);
+    }
+
+    [Fact]
+    public void All_Contains_ThreeVariants_InOrder()
+    {
+        ThumbnailVariants.All.Should().Equal("thumb", "small", "medium");
+    }
+}
+
+public sealed class ThumbnailFormatsTests
+{
+    [Theory]
+    [InlineData("webp", true)]
+    [InlineData("jpeg", true)]
+    [InlineData("png", false)]
+    [InlineData("WEBP", false)]
+    [InlineData("", false)]
+    public void IsKnown_Cases(string format, bool expected)
+    {
+        ThumbnailFormats.IsKnown(format).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
Authors the 16 STRG-329..STRG-344 child issues that decompose Phase 15
(image thumbnail generation) into shippable units, publishes the
architecture decision record at docs/architecture/06-thumbnails.md
(numbered 06 because 05-deployment.md exists), and threads Phase 15
into docs/issues/README.md alongside Phase 16 placeholders for
STRG-345/346/347.

Issue #52's Definition of Done explicitly scopes this tranche issue to
docs only — implementation is tracked on the child issues. Each child
issue is self-contained with resolved design decisions inline (no open
TBDs that block implementation sessions), Acceptance Criteria, Test
Cases (TC-001..TC-012 mapped per #52), Security/Code review checklists,
and Definition of Done.

Spec corrections folded into child issues during authoring (validated
via codebase exploration before writing):
- Drive.IsEncrypted → actual property is Drive.EncryptionEnabled
- strg_uploads_total unit "By" → byte counter is strg_upload_bytes_total
- 04-event-system.md:68 → actual line is :76
- Strg.GraphQL → actual project is Strg.GraphQl
- IStorageProvider lives in Strg.Plugin.Abstractions, not Strg.Core

https://claude.ai/code/session_014phnCcTJVUszewBLSzjCHX